### PR TITLE
Add samples per query argument in loadgen_gnmt.py

### DIFF
--- a/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py
+++ b/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py
@@ -437,7 +437,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--qps", type=int, default=10, help="target qps estimate")
     
-    parser.add_argument("--samples_per_query", type=int, default=4, help="Samples per query. Only works for Offline or MultiStream scenario")
+    parser.add_argument("--samples_per_query", type=int, default=4, help="Samples per query. Works for MultiStream scenario")
 
     parser.add_argument("--max-latency", type=str, default="0.100", help="mlperf max latency in 99pct tile")
 
@@ -450,7 +450,7 @@ if __name__ == "__main__":
     try:
         settings.mode = MODE_MAP[args.mode]
         settings.scenario = SCENARIO_MAP[args.scenario]
-        if args.scenario in ["Offline", "MultiStream"]:
+        if args.scenario == "MultiStream":
             settings.multi_stream_samples_per_query = args.samples_per_query
     except KeyError as e:
         print("Unknown mode or scenario: {}".format(e.args[0]))

--- a/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py
+++ b/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py
@@ -436,6 +436,8 @@ if __name__ == "__main__":
         help="For debugging purposes, modify settings to small number of querries.")
 
     parser.add_argument("--qps", type=int, default=10, help="target qps estimate")
+    
+    parser.add_argument("--samples_per_query", type=int, default=4, help="Samples per query. Only works for \"Offline\" or \"MultiStream\" scenario")
 
     parser.add_argument("--max-latency", type=str, default="0.100", help="mlperf max latency in 99pct tile")
 
@@ -448,6 +450,8 @@ if __name__ == "__main__":
     try:
         settings.mode = MODE_MAP[args.mode]
         settings.scenario = SCENARIO_MAP[args.scenario]
+        if args.scenario in ["Offline", "MultiStream"]:
+            settings.multi_stream_samples_per_query = args.samples_per_query
     except KeyError as e:
         print("Unknown mode or scenario: {}".format(e.args[0]))
         raise e

--- a/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py
+++ b/v0.5/translation/gnmt/tensorflow/loadgen_gnmt.py
@@ -437,7 +437,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--qps", type=int, default=10, help="target qps estimate")
     
-    parser.add_argument("--samples_per_query", type=int, default=4, help="Samples per query. Only works for \"Offline\" or \"MultiStream\" scenario")
+    parser.add_argument("--samples_per_query", type=int, default=4, help="Samples per query. Only works for Offline or MultiStream scenario")
 
     parser.add_argument("--max-latency", type=str, default="0.100", help="mlperf max latency in 99pct tile")
 


### PR DESCRIPTION
When running the loadgen_gnmt.py in MultiStream scenario, the Recommendation is:
\* Reduce samples per query to improve latency.

Add the argument ''--samples_per_query'' to set this parameter.
Refer to this issue: https://github.com/mlperf/inference/issues/352