### PR TITLE
Fix wrong IoU calculation in ssd-resnet34-pytorch

### DIFF
--- a/v0.5/classification_and_detection/python/models/ssd_r34.py
+++ b/v0.5/classification_and_detection/python/models/ssd_r34.py
@@ -113,7 +113,7 @@ def calc_iou_tensor(box1, box2):
     lt = torch.max(be1[:,:,:2], be2[:,:,:2])
     rb = torch.min(be1[:,:,2:], be2[:,:,2:])
     delta = rb - lt
-    delta.clone().masked_fill_(delta < 0,0)
+    delta.masked_fill_(delta < 0,0)
     intersect = delta[:,:,0]*delta[:,:,1]
     delta1 = be1[:,:,2:] - be1[:,:,:2]
     area1 = delta1[:,:,0]*delta1[:,:,1]


### PR DESCRIPTION
`masked_fill_` is applied on new Tensor created by `delta.clone()`, so `delta` just remains the same.
This results in negative IoU or false intersection if `right - left` and `bottom - top` are both negative. This bug can have impact on accuracy.