### PR TITLE
[ssd-resnet34] Update the post-processing for PyTorch implementation

### DIFF
--- a/v0.5/classification_and_detection/python/backend_pytorch_native.py
+++ b/v0.5/classification_and_detection/python/backend_pytorch_native.py
@@ -13,6 +13,7 @@ class BackendPytorchNative(backend.Backend):
         self.sess = None
         self.model = None
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
     def version(self):
         return torch.__version__
 
@@ -46,6 +47,12 @@ class BackendPytorchNative(backend.Backend):
 
         # prepare the backend
         self.model = self.model.to(self.device)
+
+        # Trace the model.
+        sample = torch.zeros(1, 3, 1200, 1200) 
+        traced_module = torch.jit.trace(self.model, sample)
+        self.model = traced_module 
+
         return self
 
         

--- a/v0.5/classification_and_detection/python/coco.py
+++ b/v0.5/classification_and_detection/python/coco.py
@@ -21,7 +21,7 @@ log = logging.getLogger("coco")
 
 class Coco(dataset.Dataset):
     def __init__(self, data_path, image_list, name, use_cache=0, image_size=None,
-                 image_format="NHWC", pre_process=None, count=None, cache_dir=None,use_label_map=False, split='val2017', calibrate=False):
+                 image_format="NHWC", pre_process=None, count=None, cache_dir=None,use_label_map=False):
         super().__init__()
         self.image_size = image_size
         self.image_list = []
@@ -33,11 +33,8 @@ class Coco(dataset.Dataset):
         self.data_path = data_path
         self.pre_process = pre_process
         self.use_label_map=use_label_map
-        self.split = split
-        self.calibrate = calibrate
         if not cache_dir:
-            #cache_dir = os.getcwd()
-            cache_dir = '/datasets/mlperf-v0.5/' # Centaur
+            cache_dir = os.getcwd()
         self.cache_dir = os.path.join(cache_dir, "preprocessed", name, image_format)
         # input images are in HWC
         self.need_transpose = True if image_format == "NCHW" else False
@@ -74,19 +71,8 @@ class Coco(dataset.Dataset):
             i["category"].append(catagory_ids)
             i["bbox"].append(a.get("bbox"))
 
-        # Populate list of allowed calibration images.
-        if self.calibrate:
-            import re
-            calibration_list_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../', 'calibration/COCO/coco_cal_images_list.txt')
-            with open(calibration_list_path, 'r') as f:
-                for s in f:
-                    image_name = re.split(r"\s+", s.strip())
-                    self.calibrate_whitelist.append(image_name[0])
-            log.info('Found {} white-listed calibration images.'.format(len(self.calibrate_whitelist)))
-
-
         for image_id, img in images.items():
-            image_name = os.path.join(self.split, img["file_name"])
+            image_name = os.path.join("val2017", img["file_name"])
             src = os.path.join(data_path, image_name)
             if not os.path.exists(src):
                 # if the image does not exists ignore it

--- a/v0.5/classification_and_detection/python/update_pytorch_ssd_resnet34_model.py
+++ b/v0.5/classification_and_detection/python/update_pytorch_ssd_resnet34_model.py
@@ -1,0 +1,25 @@
+import torch
+from models.ssd_r34 import SSD_R34
+
+## Load the MLPerf model.
+# Load the reference model + weights.
+model = torch.load('resnet34-ssd1200.pytorch', map_location=lambda storage, loc: storage)
+# Save just the MLPerf *weights*.
+torch.save(model.state_dict(), 'resnet34-ssd1200.state_dict.pytorch')
+
+## Create a model that uses the updated APIs.
+# Create a uninitialized model using the newer PyTorch API to support quantization and JIT:
+updated_model = SSD_R34()
+# Overlay the saved MLPerf *weights* onto the updated model definition:
+updated_model.load_state_dict(torch.load('resnet34-ssd1200.state_dict.pytorch'))
+updated_model.eval()
+# Save the updated model (updated definition + MLPerf weights):
+torch.save(updated_model, 'resnet34-ssd1200.updated.pytorch')
+
+## Trace the model.
+# Single-batch sample for shape propagation.
+sample = torch.zeros(1, 3, 1200, 1200) 
+traced_model = torch.jit.trace(updated_model, sample)
+# Test the traced model.
+traced_model_results = traced_model(sample)
+traced_model.save('resnet34-ssd1200.updated.traced.pytorch')

--- a/v0.5/classification_and_detection/pytorch/README.md
+++ b/v0.5/classification_and_detection/pytorch/README.md
@@ -1,0 +1,16 @@
+# PyTorch SSD-ResNet34
+
+## From: https://github.com/BowenBao/inference/tree/master/cloud/single_stage_detector/pytorch
+
+### Build the project with custom op support
+```
+cd v0.5/classification_and_detection/pytorch
+python setup.py develop --install-dir=.
+```
+Which should generate `v0.5/classification_and_detection/pytorch/lib/custom_ops.cpython-*-linux-gnu.so`
+
+If you get the error:
+```
+vision.cpp:7:4: error: 'struct torch::jit::RegisterOperators' has no member named 'op'
+```
+you are using a newer version of PyTorch and just need to remove the `jit` namespace per https://github.com/pytorch/pytorch/issues/29642#issuecomment-553144431

--- a/v0.5/classification_and_detection/pytorch/csrc/cpu/nms_cpu.cpp
+++ b/v0.5/classification_and_detection/pytorch/csrc/cpu/nms_cpu.cpp
@@ -1,0 +1,188 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+#include "cpu/vision.h"
+
+
+template <typename scalar_t>
+at::Tensor nms_cpu_kernel(const at::Tensor& dets,
+                          const at::Tensor& scores,
+                          const float threshold) {
+  AT_ASSERTM(!dets.type().is_cuda(), "dets must be a CPU tensor");
+  AT_ASSERTM(!scores.type().is_cuda(), "scores must be a CPU tensor");
+  AT_ASSERTM(dets.type() == scores.type(), "dets should have the same type as scores");
+
+  if (dets.numel() == 0) {
+    return at::empty({0}, dets.options().dtype(at::kLong).device(at::kCPU));
+  }
+
+  auto x1_t = dets.select(1, 0).contiguous();
+  auto y1_t = dets.select(1, 1).contiguous();
+  auto x2_t = dets.select(1, 2).contiguous();
+  auto y2_t = dets.select(1, 3).contiguous();
+
+  at::Tensor areas_t = (x2_t - x1_t) * (y2_t - y1_t);
+
+  auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
+
+  auto ndets = dets.size(0);
+  at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte).device(at::kCPU));
+
+  auto suppressed = suppressed_t.data<uint8_t>();
+  auto order = order_t.data<int64_t>();
+  auto x1 = x1_t.data<scalar_t>();
+  auto y1 = y1_t.data<scalar_t>();
+  auto x2 = x2_t.data<scalar_t>();
+  auto y2 = y2_t.data<scalar_t>();
+  auto areas = areas_t.data<scalar_t>();
+
+  for (int64_t _i = 0; _i < ndets; _i++) {
+    auto i = order[_i];
+    if (suppressed[i] == 1)
+      continue;
+    auto ix1 = x1[i];
+    auto iy1 = y1[i];
+    auto ix2 = x2[i];
+    auto iy2 = y2[i];
+    auto iarea = areas[i];
+
+    for (int64_t _j = _i + 1; _j < ndets; _j++) {
+      auto j = order[_j];
+      if (suppressed[j] == 1)
+        continue;
+      auto xx1 = std::max(ix1, x1[j]);
+      auto yy1 = std::max(iy1, y1[j]);
+      auto xx2 = std::min(ix2, x2[j]);
+      auto yy2 = std::min(iy2, y2[j]);
+
+      auto w = std::max(static_cast<scalar_t>(0), xx2 - xx1);
+      auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1);
+      auto inter = w * h;
+      auto ovr = inter / (iarea + areas[j] - inter);
+      if (ovr >= threshold)
+        suppressed[j] = 1;
+   }
+  }
+  return at::nonzero(suppressed_t == 0).squeeze(1);
+}
+
+at::Tensor nms_cpu(const at::Tensor& dets,
+               const at::Tensor& scores,
+               const double threshold) {
+  at::Tensor result;
+  AT_DISPATCH_FLOATING_TYPES(dets.scalar_type(), "nms", [&] {
+    result = nms_cpu_kernel<scalar_t>(dets, scores, threshold);
+  });
+  return result;
+}
+
+template <typename scalar_t>
+at::Tensor multi_label_nms_cpu_kernel(const at::Tensor& boxes,
+                                      const at::Tensor& scores,
+                                      const at::Tensor& max_output_boxes_per_class,
+                                      const at::Tensor& iou_threshold,
+                                      const at::Tensor& score_threshold) {
+  AT_ASSERTM(!boxes.type().is_cuda(), "boxes must be a CPU tensor");
+  AT_ASSERTM(!scores.type().is_cuda(), "scores must be a CPU tensor");
+  AT_ASSERTM(boxes.type() == scores.type(), "boxes should have the same type as scores");
+  AT_ASSERTM(boxes.size(0) == 1, "only support batch size = 1.");
+
+  if (boxes.numel() == 0) {
+    return at::empty({0}, boxes.options().dtype(at::kLong).device(at::kCPU));
+  }
+
+
+  auto max_output_per_class = max_output_boxes_per_class.data<int64_t>()[0];
+  auto iou_thres = iou_threshold.data<scalar_t>()[0];
+  auto score_thres = score_threshold.data<scalar_t>()[0];
+  //printf("score threshold is %f\n", float(score_thres));
+
+  auto dets = boxes.squeeze(0);
+  auto single_batch_scores = scores.squeeze(0);
+
+  auto nlabels = single_batch_scores.size(0);
+
+  std::vector<at::Tensor> res_tensors;
+  for (int64_t _l = 0; _l < nlabels; _l++){
+    auto lscores_t = single_batch_scores.select(0, _l).contiguous();
+    auto lscores = lscores_t.data<scalar_t>();
+
+    auto x1_t = dets.select(1, 0).contiguous();
+    auto y1_t = dets.select(1, 1).contiguous();
+    auto x2_t = dets.select(1, 2).contiguous();
+    auto y2_t = dets.select(1, 3).contiguous();
+
+    at::Tensor areas_t = (x2_t - x1_t) * (y2_t - y1_t);
+
+    auto order_t = std::get<1>(lscores_t.sort(0, /* descending=*/true));
+
+    auto ndets = dets.size(0);
+    at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte).device(at::kCPU));
+
+    auto suppressed = suppressed_t.data<uint8_t>();
+    auto order = order_t.data<int64_t>();
+    auto x1 = x1_t.data<scalar_t>();
+    auto y1 = y1_t.data<scalar_t>();
+    auto x2 = x2_t.data<scalar_t>();
+    auto y2 = y2_t.data<scalar_t>();
+    auto areas = areas_t.data<scalar_t>();
+
+    int64_t nleft = 0;
+    for (int64_t _i = 0; _i < ndets; _i++) {
+      auto i = order[_i];
+      if (lscores[i] <= score_thres || nleft >= max_output_per_class) {
+        suppressed[i] = 1;
+        continue;
+      }
+      // Add count here to match behavior of original SSD model in this repo.
+      // nleft++;
+      if (suppressed[i] == 1)
+        continue;
+      auto ix1 = x1[i];
+      auto iy1 = y1[i];
+      auto ix2 = x2[i];
+      auto iy2 = y2[i];
+      auto iarea = areas[i];
+
+      for (int64_t _j = _i + 1; _j < ndets; _j++) {
+        auto j = order[_j];
+        if (suppressed[j] == 1)
+          continue;
+        auto xx1 = std::max(ix1, x1[j]);
+        auto yy1 = std::max(iy1, y1[j]);
+        auto xx2 = std::min(ix2, x2[j]);
+        auto yy2 = std::min(iy2, y2[j]);
+
+        auto w = std::max(static_cast<scalar_t>(0), xx2 - xx1);
+        auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1);
+        auto inter = w * h;
+        auto ovr = inter / (iarea + areas[j] - inter);
+        if (ovr >= iou_thres)
+          suppressed[j] = 1;
+      }
+      // Add count here to match behavior of ONNXRuntime NMS implementation.
+      nleft++;
+    }
+    auto selected_idx = at::nonzero(suppressed_t == 0).squeeze(1);
+    auto nselected = selected_idx.size(0);
+    auto batch_idx = at::zeros({nselected}, dets.options().dtype(at::kLong).device(at::kCPU));
+    auto label_idx = at::full({nselected}, _l, dets.options().dtype(at::kLong).device(at::kCPU));
+    auto result_tensor = at::cat({batch_idx.unsqueeze(1), label_idx.unsqueeze(1), selected_idx.unsqueeze(1)}, 1);
+    res_tensors.push_back(result_tensor);
+  }
+  auto result = at::cat(res_tensors, 0);
+  return result;
+}
+
+
+
+at::Tensor multi_label_nms_cpu(const at::Tensor& boxes,
+                               const at::Tensor& scores,
+                               const at::Tensor& max_output_boxes_per_class,
+                               const at::Tensor& iou_threshold,
+                               const at::Tensor& score_threshold) {
+  at::Tensor result;
+  AT_DISPATCH_FLOATING_TYPES(boxes.scalar_type(), "multi_label_nms", [&] {
+    result = multi_label_nms_cpu_kernel<scalar_t>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold);
+  });
+  return result;
+}
+

--- a/v0.5/classification_and_detection/pytorch/csrc/cpu/vision.h
+++ b/v0.5/classification_and_detection/pytorch/csrc/cpu/vision.h
@@ -1,0 +1,15 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/* Modifications Copyright (c) Microsoft. */
+#pragma once
+#include <torch/script.h>
+
+
+at::Tensor nms_cpu(const at::Tensor& dets,
+                   const at::Tensor& scores,
+                   const double threshold);
+
+at::Tensor multi_label_nms_cpu(const at::Tensor& boxes,
+                               const at::Tensor& scores,
+                               const at::Tensor& max_output_boxes_per_class,
+                               const at::Tensor& iou_threshold,
+                               const at::Tensor& score_threshold);

--- a/v0.5/classification_and_detection/pytorch/csrc/cuda/nms.cu
+++ b/v0.5/classification_and_detection/pytorch/csrc/cuda/nms.cu
@@ -1,0 +1,131 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include <THC/THC.h>
+#include <THC/THCDeviceUtils.cuh>
+
+#include <vector>
+#include <iostream>
+
+int const threadsPerBlock = sizeof(unsigned long long) * 8;
+
+__device__ inline float devIoU(float const * const a, float const * const b) {
+  float left = max(a[0], b[0]), right = min(a[2], b[2]);
+  float top = max(a[1], b[1]), bottom = min(a[3], b[3]);
+  float width = max(right - left, 0.f), height = max(bottom - top, 0.f);
+  float interS = width * height;
+  float Sa = (a[2] - a[0]) * (a[3] - a[1]);
+  float Sb = (b[2] - b[0]) * (b[3] - b[1]);
+  return interS / (Sa + Sb - interS);
+}
+
+__global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
+                           const float *dev_boxes, unsigned long long *dev_mask) {
+  const int row_start = blockIdx.y;
+  const int col_start = blockIdx.x;
+
+  // if (row_start > col_start) return;
+
+  const int row_size =
+        min(n_boxes - row_start * threadsPerBlock, threadsPerBlock);
+  const int col_size =
+        min(n_boxes - col_start * threadsPerBlock, threadsPerBlock);
+
+  __shared__ float block_boxes[threadsPerBlock * 5];
+  if (threadIdx.x < col_size) {
+    block_boxes[threadIdx.x * 5 + 0] =
+        dev_boxes[(threadsPerBlock * col_start + threadIdx.x) * 5 + 0];
+    block_boxes[threadIdx.x * 5 + 1] =
+        dev_boxes[(threadsPerBlock * col_start + threadIdx.x) * 5 + 1];
+    block_boxes[threadIdx.x * 5 + 2] =
+        dev_boxes[(threadsPerBlock * col_start + threadIdx.x) * 5 + 2];
+    block_boxes[threadIdx.x * 5 + 3] =
+        dev_boxes[(threadsPerBlock * col_start + threadIdx.x) * 5 + 3];
+    block_boxes[threadIdx.x * 5 + 4] =
+        dev_boxes[(threadsPerBlock * col_start + threadIdx.x) * 5 + 4];
+  }
+  __syncthreads();
+
+  if (threadIdx.x < row_size) {
+    const int cur_box_idx = threadsPerBlock * row_start + threadIdx.x;
+    const float *cur_box = dev_boxes + cur_box_idx * 5;
+    int i = 0;
+    unsigned long long t = 0;
+    int start = 0;
+    if (row_start == col_start) {
+      start = threadIdx.x + 1;
+    }
+    for (i = start; i < col_size; i++) {
+      if (devIoU(cur_box, block_boxes + i * 5) > nms_overlap_thresh) {
+        t |= 1ULL << i;
+      }
+    }
+    const int col_blocks = THCCeilDiv(n_boxes, threadsPerBlock);
+    dev_mask[cur_box_idx * col_blocks + col_start] = t;
+  }
+}
+
+// boxes is a N x 5 tensor
+at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
+  using scalar_t = float;
+  AT_ASSERTM(boxes.type().is_cuda(), "boxes must be a CUDA tensor");
+  auto scores = boxes.select(1, 4);
+  auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
+  auto boxes_sorted = boxes.index_select(0, order_t);
+
+  int boxes_num = boxes.size(0);
+
+  const int col_blocks = THCCeilDiv(boxes_num, threadsPerBlock);
+
+  scalar_t* boxes_dev = boxes_sorted.data<scalar_t>();
+
+  THCState *state = at::globalContext().lazyInitCUDA(); // TODO replace with getTHCState
+
+  unsigned long long* mask_dev = NULL;
+  //THCudaCheck(THCudaMalloc(state, (void**) &mask_dev,
+  //                      boxes_num * col_blocks * sizeof(unsigned long long)));
+
+  mask_dev = (unsigned long long*) THCudaMalloc(state, boxes_num * col_blocks * sizeof(unsigned long long));
+
+  dim3 blocks(THCCeilDiv(boxes_num, threadsPerBlock),
+              THCCeilDiv(boxes_num, threadsPerBlock));
+  dim3 threads(threadsPerBlock);
+  nms_kernel<<<blocks, threads>>>(boxes_num,
+                                  nms_overlap_thresh,
+                                  boxes_dev,
+                                  mask_dev);
+
+  std::vector<unsigned long long> mask_host(boxes_num * col_blocks);
+  THCudaCheck(cudaMemcpy(&mask_host[0],
+                        mask_dev,
+                        sizeof(unsigned long long) * boxes_num * col_blocks,
+                        cudaMemcpyDeviceToHost));
+
+  std::vector<unsigned long long> remv(col_blocks);
+  memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);
+
+  at::Tensor keep = at::empty({boxes_num}, boxes.options().dtype(at::kLong).device(at::kCPU));
+  int64_t* keep_out = keep.data<int64_t>();
+
+  int num_to_keep = 0;
+  for (int i = 0; i < boxes_num; i++) {
+    int nblock = i / threadsPerBlock;
+    int inblock = i % threadsPerBlock;
+
+    if (!(remv[nblock] & (1ULL << inblock))) {
+      keep_out[num_to_keep++] = i;
+      unsigned long long *p = &mask_host[0] + i * col_blocks;
+      for (int j = nblock; j < col_blocks; j++) {
+        remv[j] |= p[j];
+      }
+    }
+  }
+
+  THCudaFree(state, mask_dev);
+  // TODO improve this part
+  return std::get<0>(order_t.index({
+                       keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(
+                         order_t.device(), keep.scalar_type())
+                     }).sort(0, false));
+}

--- a/v0.5/classification_and_detection/pytorch/csrc/cuda/vision.h
+++ b/v0.5/classification_and_detection/pytorch/csrc/cuda/vision.h
@@ -1,0 +1,6 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+#pragma once
+#include <torch/extension.h>
+
+
+at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh);

--- a/v0.5/classification_and_detection/pytorch/csrc/nms.h
+++ b/v0.5/classification_and_detection/pytorch/csrc/nms.h
@@ -1,0 +1,38 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+#pragma once
+#include "cpu/vision.h"
+
+#ifdef WITH_CUDA
+#include "cuda/vision.h"
+#endif
+
+
+at::Tensor nms(const at::Tensor& dets,
+               const at::Tensor& scores,
+               const double threshold) {
+
+  if (dets.type().is_cuda()) {
+#ifdef WITH_CUDA
+    // TODO raise error if not compiled with CUDA
+    if (dets.numel() == 0)
+      return at::empty({0}, dets.options().dtype(at::kLong).device(at::kCPU));
+    auto b = at::cat({dets, scores.unsqueeze(1)}, 1);
+    return nms_cuda(b, threshold);
+#else
+    AT_ERROR("Not compiled with GPU support");
+#endif
+  }
+
+  at::Tensor result = nms_cpu(dets, scores, threshold);
+  return result;
+}
+
+
+at::Tensor multi_label_nms(const at::Tensor& boxes,
+                           const at::Tensor& scores,
+                           const at::Tensor& max_output_boxes_per_class,
+                           const at::Tensor& iou_threshold,
+                           const at::Tensor& score_threshold) {
+  at::Tensor result = multi_label_nms_cpu(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold);
+  return result;
+}

--- a/v0.5/classification_and_detection/pytorch/csrc/vision.cpp
+++ b/v0.5/classification_and_detection/pytorch/csrc/vision.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+#include "torch/extension.h"
+
+#include "nms.h"
+
+//static auto registry = torch::jit::RegisterOperators() // PyTorch <= 1.4?
+static auto registry = torch::RegisterOperators() // PyTorch > 1.4?
+  .op("roi_ops::nms", &nms)
+  .op("roi_ops::multi_label_nms", &multi_label_nms);
+     
+#ifndef NO_PYTHON
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("nms", &nms, "non-maximum suppression");
+  m.def("multi_label_nms", &multi_label_nms, "multi label non-maximum suppression");
+}
+#endif

--- a/v0.5/classification_and_detection/pytorch/setup.py
+++ b/v0.5/classification_and_detection/pytorch/setup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import os
+
+import torch
+from setuptools import find_packages
+from setuptools import setup
+import distutils.command.build
+
+from torch.utils.cpp_extension import CUDA_HOME
+from torch.utils.cpp_extension import CppExtension
+from torch.utils.cpp_extension import CUDAExtension
+
+requirements = ["torch", "torchvision"]
+
+def get_extensions():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    lib_dir = os.path.join(this_dir, 'lib')
+    if not os.path.isdir(lib_dir):
+        os.mkdir(lib_dir)
+    extensions_dir = os.path.join(this_dir, 'csrc')
+
+    extension = CppExtension
+
+    custom_ops_sources = [os.path.join(extensions_dir, 'vision.cpp')]
+    custom_ops_sources += [os.path.join(extensions_dir, 'cpu', 'nms_cpu.cpp')]
+    custom_ops_sources_cuda = [os.path.join(extensions_dir, 'cuda', 'nms.cu')]
+
+    extra_compile_args = {'cxx': []}
+    define_macros = []
+
+    if torch.cuda.is_available() and CUDA_HOME is not None:
+        extension = CUDAExtension
+        custom_ops_sources += custom_ops_sources_cuda
+        define_macros += [('WITH_CUDA', None)]
+        extra_compile_args["nvcc"] = [
+            "-DCUDA_HAS_FP16=1",
+            "-D__CUDA_NO_HALF_OPERATORS__",
+            "-D__CUDA_NO_HALF_CONVERSIONS__",
+            "-D__CUDA_NO_HALF2_OPERATORS__",
+        ]
+
+    include_dirs = [extensions_dir]
+
+    ext_modules = [
+        extension(
+            "lib.custom_ops",
+            custom_ops_sources,
+            include_dirs=include_dirs,
+            define_macros=define_macros,
+            extra_compile_args=extra_compile_args,
+        ),
+    ]
+
+    return ext_modules
+
+setup(
+    name="custom_nms_ops",
+    version="0.1",
+    author="bowbao",
+    packages=find_packages(),
+    ext_modules=get_extensions(),
+    cmdclass={"build_ext": torch.utils.cpp_extension.BuildExtension,
+              "build": distutils.command.build.build}
+)


### PR DESCRIPTION
See this issue: https://github.com/mlperf/inference/issues/657

This just borrows the post-processing implementation from the ONNX branch:  https://github.com/BowenBao/inference/tree/master/cloud/single_stage_detector/pytorch

Note users would need to build the custom op (C++), see instructions in https://github.com/mlperf/inference/compare/master...parvizp:ssd_r34_update_post_processing_cleaned?expand=1#diff-aae2ac86d93b3e254c23aa485ca9dc2e