### PR TITLE
[BERT] Make compatible with both TF v1 and v2 by using tf.compat.v1

### DIFF
--- a/language/bert/create_squad_data.py
+++ b/language/bert/create_squad_data.py
@@ -31,7 +31,7 @@ import tensorflow as tf
 # import horovod.tensorflow as hvd
 import time
 
-flags = tf.flags
+flags = tf.compat.v1.flags
 FLAGS = None
 
 def extract_flags():
@@ -154,7 +154,7 @@ class InputFeatures(object):
 
 def read_squad_examples(input_file, is_training, version_2_with_negative=False):
   """Read a SQuAD json file into a list of SquadExample."""
-  with tf.gfile.Open(input_file, "r") as reader:
+  with tf.compat.v1.gfile.Open(input_file, "r") as reader:
     input_data = json.load(reader)["data"]
 
   def is_whitespace(c):

--- a/language/bert/tf_SUT.py
+++ b/language/bert/tf_SUT.py
@@ -29,9 +29,9 @@ from squad_QSL import get_squad_QSL
 class BERT_TF_SUT():
     def __init__(self):
         print("Loading TF model...")
-        self.sess = tf.Session()
+        self.sess = tf.compat.v1.Session()
         with gfile.FastGFile('build/data/bert_tf_v1_1_large_fp32_384_v2/model.pb', 'rb') as f:
-            graph_def = tf.GraphDef()
+            graph_def = tf.compat.v1.GraphDef()
             graph_def.ParseFromString(f.read())
             self.sess.graph.as_default()
             tf.import_graph_def(graph_def, name='')


### PR DESCRIPTION
Using the reference BERT implementation [outside of Docker](https://github.com/mlperf/inference/pull/756) fails with TensorFlow v2. Patching the implementation with `tf.compat.v1` allows it to work both with TF v1.14 inside the Docker image and TF v2 outside the Docker image (tested with TF v2.3.1).