### PR TITLE
Update backend_tf.py

### DIFF
--- a/vision/classification_and_detection/python/backend_tf.py
+++ b/vision/classification_and_detection/python/backend_tf.py
@@ -40,7 +40,7 @@ class BackendTensorflow(backend.Backend):
         infer_config.intra_op_parallelism_threads = int(os.environ['MLPERF_NUM_INTRA_THREADS']) \
                 if 'MLPERF_NUM_INTRA_THREADS' in os.environ else os.cpu_count()
         infer_config.inter_op_parallelism_threads = int(os.environ['MLPERF_NUM_INTER_THREADS']) \
-                if 'MLPERF_NUM_INTER_THREADS' in os.environ else 1
+                if 'MLPERF_NUM_INTER_THREADS' in os.environ else os.cpu_count()
         infer_config.use_per_session_threads = 1
 
         # TODO: support checkpoint and saved_model formats?

--- a/vision/classification_and_detection/python/backend_tf.py
+++ b/vision/classification_and_detection/python/backend_tf.py
@@ -6,7 +6,10 @@ tensorflow backend (https://github.com/tensorflow/tensorflow)
 
 import tensorflow as tf
 from tensorflow.core.framework import graph_pb2
+from tensorflow.python.tools.optimize_for_inference_lib import optimize_for_inference
+from tensorflow.python.framework import dtypes
 
+import os
 import backend
 
 
@@ -33,12 +36,29 @@ class BackendTensorflow(backend.Backend):
         self.outputs = outputs
         self.inputs = inputs
 
+        infer_config = tf.compat.v1.ConfigProto()
+        infer_config.intra_op_parallelism_threads = int(os.environ['MLPERF_NUM_INTRA_THREADS']) \
+                if 'MLPERF_NUM_INTRA_THREADS' in os.environ else os.cpu_count()
+        infer_config.inter_op_parallelism_threads = int(os.environ['MLPERF_NUM_INTER_THREADS']) \
+                if 'MLPERF_NUM_INTER_THREADS' in os.environ else 1
+        infer_config.use_per_session_threads = 1
+
         # TODO: support checkpoint and saved_model formats?
-        graph_def = graph_pb2.GraphDef()
-        with open(model_path, "rb") as f:
+        graph_def = tf.compat.v1.GraphDef()
+        with tf.compat.v1.gfile.FastGFile(model_path, "rb") as f:
             graph_def.ParseFromString(f.read())
-        g = tf.compat.v1.import_graph_def(graph_def, name='')
-        self.sess = tf.compat.v1.Session(graph=g)
+        try:
+            optimized_graph_def = optimize_for_inference(graph_def, [item.split(':')[0] for item in inputs],
+                    [item.split(':')[0] for item in outputs], dtypes.float32.as_datatype_enum, False)
+            g = tf.compat.v1.import_graph_def(optimized_graph_def, name='')
+        except ValueError:
+            try:
+                optimized_graph_def = optimize_for_inference(graph_def, [item.split(':')[0] for item in inputs],
+                        [item.split(':')[0] for item in outputs], dtypes.uint8.as_datatype_enum, False)
+                g = tf.compat.v1.import_graph_def(optimized_graph_def, name='')
+            except ValueError:
+                g = tf.compat.v1.import_graph_def(graph_def, name='')
+        self.sess = tf.compat.v1.Session(graph=g, config=infer_config)
         return self
 
     def predict(self, feed):


### PR DESCRIPTION
The current code for TF session creation in backend_tf.py uses default thread configuration, leading to poorer OneDNN performance than Eigen. The proposed code change explicitly configures intra_op_parallelism_threads and inter_op_parallelism_threads either according to the values of two new environment variables or the default values. In addition, the revised code calls TF's optimize_for_inference function to optimize the graph of a CNN model for the best possible performance.

The following are the Resnet50 SingleStream 90-percentile latencies (unit: millisecond) on a SMT-disabled c5.4xlarge AWS EC2 instance w/ the original code and the revised code, respectively.

stock eigen: (original) 24.1ms, (revised) 23.7ms
onednn v1.6.5: (original) 69ms, (revised) 12.9ms