### PR TITLE
fix a bug that causes exception in check_performance_dir

### DIFF
--- a/tools/submission/submission-checker.py
+++ b/tools/submission/submission-checker.py
@@ -576,6 +576,8 @@ def check_performance_dir(config, model, path):
         min_query_count = mlperf_log["effective_min_query_count"]
         samples_per_query = mlperf_log["effective_samples_per_query"]
         min_duration = mlperf_log["effective_min_duration_ms"]
+        rt["Scenario"] = scenario
+        rt["QPS w/o loadgen overhead"] = mlperf_log.get("QPS w/o loadgen overhead")
     else:
         fname = os.path.join(path, "mlperf_log_summary.txt")
         with open(fname, "r") as f:


### PR DESCRIPTION
Current submission checker is broken on tot, it always hit ERROR for 
caused exception in check_performance_dir: 'Scenario'
The root cause looks like disconnection between the new code path of check_performance_dir and the logic of infer QPS from singlestream.
