### PR TITLE
Change the format bert/run.py launches the accuracy-squad scripts

### DIFF
--- a/language/bert/run.py
+++ b/language/bert/run.py
@@ -92,7 +92,7 @@ def main():
     lg.StartTestWithLogSettings(sut.sut, sut.qsl.qsl, settings, log_settings)
 
     if args.accuracy:
-        cmd = "python3 {:}/accuracy-squad.py {}".format(os.path.dirname(__file__), '--max_examples={}'.format(args.max_examples) if args.max_examples else '')
+        cmd = "python3 {:}/accuracy-squad.py {}".format(os.path.dirname(os.path.abspath(__file__)), '--max_examples={}'.format(args.max_examples) if args.max_examples else '')
         subprocess.check_call(cmd, shell=True)
 
     print("Done!")


### PR DESCRIPTION
Launching bert locally with run.py --accuracy fails, showing
`"python3: can't open file '/accuracy-squad.py': [Errno 2] No such file or directory"`
This happens because `format(os.path.dirname(__file__), ...` returns an empty string. The script then tries to launch "/accuracy-squad.py".
Changing it to `format(os.path.dirname(os.path.abspath(__file__)), ...` returns the actual folder.
Tested locally and with the docker image, working in both cases. 