### PR TITLE
Add Power WG's check.py checking to submission checker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "vision/medical_imaging/3d-unet/nnUnet"]
 	path = vision/medical_imaging/3d-unet/nnUnet
 	url = https://github.com/MIC-DKFZ/nnUNet.git
+[submodule "tools/submission/power-dev"]
+	path = tools/submission/power-dev
+	url = ../power-dev


### PR DESCRIPTION
Add Power WG's check.py checking to submission checker

- Add power-dev, where Power WG puts the check.py, as a submodule.
- Apply check.py on each of the power submission.
- Enabled by adding `--more-power-check` flag because the check.py requires Python 3.7+, which some may not have.
- Also sort the result printing for better readability.