### PR TITLE
Use size_t in ArgValueTransform for vector

### DIFF
--- a/loadgen/logging.cc
+++ b/loadgen/logging.cc
@@ -128,7 +128,7 @@ const std::string ArgValueTransform(const char* value) {
   return std::string("\"") + std::string(value) + std::string("\"");
 }
 
-const std::string ArgValueTransform(const std::vector<uint64_t>& value) {
+const std::string ArgValueTransform(const std::vector<size_t>& value) {
   std::string s("[");
   for (auto i : value) {
     s += std::to_string(i) + ",";

--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -85,7 +85,7 @@ const std::string ArgValueTransform(const LogBinaryAsHexString& value);
 const std::string ArgValueTransform(const std::string& value);
 const std::string ArgValueTransform(const char* value);
 /// \brief Prints a list of int in JSON format.
-const std::string ArgValueTransform(const std::vector<uint64_t>& value);
+const std::string ArgValueTransform(const std::vector<size_t>& value);
 /// \brief Prints a dict in JSON format.
 const std::string ArgValueTransform(
     const std::map<std::string, std::string>& value);


### PR DESCRIPTION
`ArgValueTransform(std::vector)` is used for printing `std::vector<IssueSampleIndex>`.
`IssueSampleIndex` is a typedef for `size_t`.
Apparently, on some compilers `size_t` maps to the same type as `uint64_t`.
However, on some compilers `size_t` maps to `unsigned long` while `uint64_t` maps to `unsigned long long`, and this breaks compilation, because `std::vector<unsigned long>` is incompatible with `std::vector<unsigned long long>`.

`ArgValueTransform(std::vector)` doesn't seem to be used for other types, so I simply changed the function signature.

Should fix https://github.com/mlcommons/inference/issues/966