### PR TITLE
Improve memory usage of RNN-T encoder StackTime module

### DIFF
--- a/speech_recognition/rnnt/pytorch/rnn.py
+++ b/speech_recognition/rnnt/pytorch/rnn.py
@@ -104,7 +104,6 @@ class StackTime(torch.nn.Module):
         s = r.shape
         rs = [s[0], s[1] // self.factor, s[2] * self.factor]
         r = torch.reshape(r, rs)
-        numer = x_lens + (self.factor * 2 - 1)
-        x_lens = torch.div(numer, self.factor, rounding_mode="trunc") - 1
         rt = torch.transpose(r, 0, 1)
+        x_lens = torch.ceil(x_lens.float() / self.factor).int()
         return rt, x_lens

--- a/speech_recognition/rnnt/pytorch/rnn.py
+++ b/speech_recognition/rnnt/pytorch/rnn.py
@@ -99,7 +99,7 @@ class StackTime(torch.nn.Module):
         r = torch.transpose(x, 0, 1)
         s = r.shape
         zeros = torch.zeros(
-			s[0], (-s[1]) % self.factor, s[2], dtype=r.dtype, device=r.device)
+            s[0], (-s[1]) % self.factor, s[2], dtype=r.dtype, device=r.device)
         r = torch.cat([r, zeros], 1)
         s = r.shape
         rs = [s[0], s[1] // self.factor, s[2] * self.factor]

--- a/speech_recognition/rnnt/pytorch/rnn.py
+++ b/speech_recognition/rnnt/pytorch/rnn.py
@@ -96,12 +96,15 @@ class StackTime(torch.nn.Module):
 
     def forward(self, x, x_lens):
         # T, B, U
-        seq = [x]
-        for i in range(1, self.factor):
-            # This doesn't seem to make much sense...
-            tmp = torch.zeros_like(x)
-            tmp[:-i, :, :] = x[i:, :, :]
-            seq.append(tmp)
-        x_lens = torch.ceil(x_lens.float() / self.factor).int()
-        # Gross, this is horrible. What a waste of memory...
-        return torch.cat(seq, dim=2)[::self.factor, :, :], x_lens
+        r = torch.transpose(x, 0, 1)
+        s = r.shape
+        zeros = torch.zeros(
+			s[0], (-s[1]) % self.factor, s[2], dtype=r.dtype, device=r.device)
+        r = torch.cat([r, zeros], 1)
+        s = r.shape
+        rs = [s[0], s[1] // self.factor, s[2] * self.factor]
+        r = torch.reshape(r, rs)
+        numer = x_lens + (self.factor * 2 - 1)
+        x_lens = torch.div(numer, self.factor, rounding_mode="trunc") - 1
+        rt = torch.transpose(r, 0, 1)
+        return rt, x_lens

--- a/tools/submission/generate-final-report.py
+++ b/tools/submission/generate-final-report.py
@@ -80,6 +80,10 @@ def main():
     df1.to_excel(writer, sheet_name="open,datacenter")
     df1 = df[(df['Category'] == "open") & (df['Suite'] == "edge")].pivot_table(index=index, columns=columns, values=['Result']).fillna("")
     df1.to_excel(writer, sheet_name="open,edge")
+
+    format = writer.book.add_format({"num_format": "#,##0.00"})
+    for ws in writer.book.worksheets():
+        ws.set_column(len(index), 100, None, format)
     
     writer.save()
     


### PR DESCRIPTION
The previous implementation of the RNN-T encoder StackTime module is slow and memory-inefficient. I will also make a PR to fix this snippet in the MLCommons-Training repo.