### PR TITLE
Update 3d-unet-brats19 Dockerfile 

### DIFF
--- a/vision/medical_imaging/3d-unet-brats19/Dockerfile
+++ b/vision/medical_imaging/3d-unet-brats19/Dockerfile
@@ -33,8 +33,10 @@ RUN python3 -m pip install onnx numpy==1.18.0 Pillow==7.0.0 tensorflow
 RUN python3 -m pip install tensorflow-addons https://github.com/onnx/onnx-tensorflow/archive/master.zip
 
 # Install onnxruntime
-# TODO: Switch to release version with 3D TransposedConvolution support.
-RUN python3 -m pip install -i https://test.pypi.org/simple/ ort-nightly
+RUN python3 -m pip install onnxruntime>=1.7.0
+
+# Install batchgenerators to be compatible with nnUnet
+RUN python3 -m pip install batchgenerators<=0.21
 
 # Install nnUnet
 COPY nnUnet /workspace/nnUnet


### PR DESCRIPTION
This PR makes two updates to the Dockerfile:
 - onnxruntime fully supports 3D TransposedConvolution as of v1.7.0, so we use the release version instead
 - batchgenerators after v0.21 has a different package namespace, making it incompatible with nnUnet @ b38c69b. For example, `from batchgenerators.transforms import AbstractTransform` [here](https://github.com/MIC-DKFZ/nnUNet/blob/b38c69b345b2f60cd0d053039669e8f988b0c0af/nnunet/training/data_augmentation/custom_transforms.py#L16) no longer works. So we ensure an earlier version is installed.