### PR TITLE
Sample sequence of permutations for equal distributed dataset

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -246,10 +246,12 @@ std::vector<QueryMetadata> GenerateQueries(
   auto schedule_distribution =
       ScheduleDistribution<scenario>(settings.target_qps);
 
-  // When sample_concatenate_permutation is turned on, pad to a multiple of the 
+  // When sample_concatenate_permutation is turned on, pad to a multiple of the
   // complete dataset to ensure complete fairness.
-  if (settings.sample_concatenate_permutation && (samples_per_query%loaded_samples.size() != 0)){
-    size_t pad_size = (loaded_samples.size() - samples_per_query%loaded_samples.size());
+  if (settings.sample_concatenate_permutation &&
+      samples_per_query % loaded_samples.size() != 0) {
+    size_t pad_size =
+        (loaded_samples.size() - samples_per_query % loaded_samples.size());
     samples_per_query += pad_size;
   }
   std::vector<QuerySampleIndex> samples(samples_per_query);
@@ -290,18 +292,18 @@ std::vector<QueryMetadata> GenerateQueries(
           std::copy(loaded_samples.begin(), loaded_samples.end(),
                     samples.begin() + i * num_loaded_samples);
 
-          if (settings.sample_concatenate_permutation){
+          if (settings.sample_concatenate_permutation) {
             std::shuffle(samples.begin() + i * num_loaded_samples,
-                        samples.begin() + (i+1) * num_loaded_samples, sample_rng);
+                         samples.begin() + (i + 1) * num_loaded_samples,
+                         sample_rng);
           }
         }
 
         std::copy(loaded_samples.begin(), loaded_samples.begin() + remainder,
                   samples.begin() + num_full_repeats * num_loaded_samples);
 
-        if (settings.sample_concatenate_permutation){
-          std::shuffle(samples.begin() + num_full_repeats * num_loaded_samples,
-                      samples.end(), sample_rng);
+        if (settings.sample_concatenate_permutation) {
+          assert(remainder == 0);
         }
       }
     } else {

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -283,10 +283,20 @@ std::vector<QueryMetadata> GenerateQueries(
         for (size_t i = 0; i < num_full_repeats; ++i) {
           std::copy(loaded_samples.begin(), loaded_samples.end(),
                     samples.begin() + i * num_loaded_samples);
+
+          if (settings.sample_concatenate_permutation){
+            std::shuffle(samples.begin() + i * num_loaded_samples,
+                        samples.begin() + (i+1) * num_loaded_samples, sample_rng);
+          }
         }
 
         std::copy(loaded_samples.begin(), loaded_samples.begin() + remainder,
                   samples.begin() + num_full_repeats * num_loaded_samples);
+
+        if (settings.sample_concatenate_permutation){
+          std::shuffle(samples.begin() + num_full_repeats * num_loaded_samples,
+                      samples.end(), sample_rng);
+        }
       }
     } else {
       for (auto& s : samples) {

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -246,6 +246,12 @@ std::vector<QueryMetadata> GenerateQueries(
   auto schedule_distribution =
       ScheduleDistribution<scenario>(settings.target_qps);
 
+  // When sample_concatenate_permutation is turned on, pad to a multiple of the 
+  // complete dataset to ensure complete fairness.
+  if (settings.sample_concatenate_permutation && (samples_per_query%loaded_samples.size() != 0)){
+    size_t pad_size = (loaded_samples.size() - samples_per_query%loaded_samples.size());
+    samples_per_query += pad_size;
+  }
   std::vector<QuerySampleIndex> samples(samples_per_query);
   std::chrono::nanoseconds timestamp(0);
   std::chrono::nanoseconds prev_timestamp(0);

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -225,6 +225,14 @@ struct TestSettings {
   /// The loadgen generates 10% more queries than it thinks it needs to meet
   /// the minimum test duration.
   double offline_expected_qps = 1;
+  /// \brief Affects the order in which the samples of the dataset are chosen.
+  /// If false it concatenates a single permutation of the dataset (or part
+  /// of it depending on QSL->PerformanceSampleCount()) several times up to the 
+  /// number of samples requested.
+  /// If true it concatenates a multiple permutation of the dataset (or a 
+  /// part of it depending on QSL->PerformanceSampleCount()) several times  
+  /// up to the number of samples requested.
+  bool sample_concatenate_permutation = false;
   /**@}*/
 
   // ==================================

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -47,7 +47,8 @@ TestSettingsInternal::TestSettingsInternal(
       performance_issue_unique(requested.performance_issue_unique),
       performance_issue_same(requested.performance_issue_same),
       performance_issue_same_index(requested.performance_issue_same_index),
-      performance_sample_count(0) {
+      performance_sample_count(0),
+      sample_concatenate_permutation(false) {
   // Target QPS, target latency, and max_async_queries.
   switch (requested.scenario) {
     case TestScenario::SingleStream:
@@ -128,6 +129,12 @@ TestSettingsInternal::TestSettingsInternal(
   performance_sample_count = (requested.performance_sample_count_override == 0)
                                  ? qsl_performance_sample_count
                                  : requested.performance_sample_count_override;
+
+  // Sample by concatentating several permutations of the dataset
+  // sample_concatenate_permutation
+  sample_concatenate_permutation = (requested.sample_concatenate_permutation == 0)
+                                    ? false
+                                    : requested.sample_concatenate_permutation;
 
   // Samples per query.
   if (requested.scenario == TestScenario::MultiStream ||
@@ -696,6 +703,9 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
 
   // keys that apply to Offline
   lookupkv(model, "Offline", "target_qps", 0, &offline_expected_qps);
+  if (lookupkv(model, "Offline", "sample_concatenate_permutation", &val, nullptr))
+    sample_concatenate_permutation = (val == 0) ? false : true;
+  
 
   return 0;
 }

--- a/loadgen/test_settings_internal.h
+++ b/loadgen/test_settings_internal.h
@@ -80,6 +80,8 @@ struct TestSettingsInternal {
   bool performance_issue_same;
   uint64_t performance_issue_same_index;
   uint64_t performance_sample_count;
+
+  bool sample_concatenate_permutation;
 };
 
 /// \brief A namespace of collections of FindPeakPerformance helper functions,

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -13,7 +13,7 @@ ssd-resnet34.*.performance_sample_count_override = 64
 bert.*.performance_sample_count_override = 10833
 dlrm.*.performance_sample_count_override = 204800
 rnnt.*.performance_sample_count_override = 2513
-3d-unet.*.performance_sample_count_override = 16
+3d-unet.*.performance_sample_count_override = 0
 
 # Set seeds. The seeds will be distributed two weeks before the submission.
 # 0x168ad48ada698a73
@@ -40,7 +40,6 @@ gnmt.MultiStream.target_latency = 100
 gnmt.MultiStream.target_qps = 10
 gnmt.MultiStream.target_latency_percentile = 97
 3d-unet.Offline.sample_concatenate_permutation = 1
-3d-unet.Offline.performance_sample_count_override = 0
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -39,6 +39,8 @@ gnmt.MultiStream.min_query_count = 90112
 gnmt.MultiStream.target_latency = 100
 gnmt.MultiStream.target_qps = 10
 gnmt.MultiStream.target_latency_percentile = 97
+3d-unet.Offline.sample_concatenate_permutation = 1
+3d-unet.Offline.performance_sample_count_override = 0
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99

--- a/vision/medical_imaging/3d-unet-kits19/run.py
+++ b/vision/medical_imaging/3d-unet-kits19/run.py
@@ -93,7 +93,7 @@ def get_args():
                         help="path to preprocessed data")
     parser.add_argument("--performance_count",
                         type=int,
-                        default=16,
+                        default=None,
                         help="performance count")
     args = parser.parse_args()
     return args


### PR DESCRIPTION
Fixes mlcommons/inference#1024
Changes to loadgen:
- Adds flag sample_concatenate_permutation to the TestSetting configuration. False by default
- If true, loadgen will generate in offline mode the sample indices by concatenating several permutation of the dataset (using the method std::shuffle, the object sample_rng and the seed sample_index_rng_seed)

Changes to 3d-unet-kits19:
- Changes the default value of performance_count from 16 to None. This implies loadgen will generate sample indices over the whole dataset, not only over 16 samples.
- Sets the flag sample_concatenate_permutation to 1 in mlperf.conf
- Sets the flag performance_sample_count_override to 0 in mlperf.conf. So that loadgen does not overwrite the value of performance_count
