### PR TITLE
Add githooks directory to track hooks

### DIFF
--- a/tools/githooks/README.md
+++ b/tools/githooks/README.md
@@ -1,0 +1,5 @@
+# Git Hooks
+## Description
+This folder contains git hooks to help with the development and code maintenance of this repository. Each of the hooks is triggered by a specific git action.
+## Setup
+Set this folder as a custom hooks directory, so git will automatically apply the hooks in this folder. This can be done with git >= 2.9 with the command ```git config core.hooksPath tools/githooks```. Then set the hook file as an executable by running ```chmod u+x <path to file>```

--- a/tools/githooks/pre-commit
+++ b/tools/githooks/pre-commit
@@ -1,0 +1,28 @@
+#================================================================
+# HEADER
+#================================================================
+# DESCRIPTION
+#    This is a git hook containing some commands to help you
+#    automatically format the code. This will help to maintain
+#    good quality code in the github repository. This script
+#    will be executed before every commit you make.
+# SET UP
+#    Set the folder containing this file as a custom hooks
+#    directory. This can be done with git >= 2.9 with the 
+#    command git config core.hooksPath tools/githooks. Then 
+#    set the hook file as an executable by running 
+#    chmod u+x <path to file>
+# REQUIREMENTS
+#    clang-format
+#================================================================
+# END_OF_HEADER
+#================================================================
+
+
+# Checks all the modified c/c++ files, format them and adds them
+# to the commit.
+for FILE in $(git diff --cached --name-only | grep -E '.*\.(cc|cpp|h|hpp)$')
+do
+    clang-format -i -style=file $FILE
+    git add $FILE
+done


### PR DESCRIPTION
- Add folder containing githooks and instructions for setting them up.
- Currently only contains a pre-commit hook to apply clang-format to all c++ files