### PR TITLE
Add audit.config file path as parameter

### DIFF
--- a/loadgen/bindings/c_api.cc
+++ b/loadgen/bindings/c_api.cc
@@ -139,13 +139,15 @@ void DestroyQSL(void* qsl) {
 
 // mlperf::c::StartTest just forwards to mlperf::StartTest after doing the
 // proper cast.
-void StartTest(void* sut, void* qsl, const TestSettings& settings) {
+void StartTest(void* sut, void* qsl, const TestSettings& settings,
+               const std::string& audit_config_filename = "audit.config") {
   SystemUnderTestTrampoline* sut_cast =
       reinterpret_cast<SystemUnderTestTrampoline*>(sut);
   QuerySampleLibraryTrampoline* qsl_cast =
       reinterpret_cast<QuerySampleLibraryTrampoline*>(qsl);
   LogSettings default_log_settings;
-  mlperf::StartTest(sut_cast, qsl_cast, settings, default_log_settings);
+  mlperf::StartTest(sut_cast, qsl_cast, settings, default_log_settings,
+                    audit_config_filename);
 }
 
 void QuerySamplesComplete(QuerySampleResponse* responses,

--- a/loadgen/bindings/c_api.h
+++ b/loadgen/bindings/c_api.h
@@ -75,7 +75,8 @@ void DestroyQSL(void* qsl);
 /// \brief Run tests on a SUT created by ConstructSUT().
 /// \details This is the C entry point. See mlperf::StartTest for the C++ entry
 /// point.
-void StartTest(void* sut, void* qsl, const TestSettings& settings);
+void StartTest(void* sut, void* qsl, const TestSettings& settings,
+               const std::string& audit_config_filename);
 
 ///
 /// \brief Register a thread for query issuing in Server scenario.

--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -191,26 +191,29 @@ void DestroyQSL(uintptr_t qsl) {
   delete qsl_cast;
 }
 
-void StartTest(uintptr_t sut, uintptr_t qsl,
-               mlperf::TestSettings test_settings) {
+void StartTest(uintptr_t sut, uintptr_t qsl, mlperf::TestSettings test_settings,
+               const std::string& audit_config_filename) {
   pybind11::gil_scoped_release gil_releaser;
   SystemUnderTestTrampoline* sut_cast =
       reinterpret_cast<SystemUnderTestTrampoline*>(sut);
   QuerySampleLibraryTrampoline* qsl_cast =
       reinterpret_cast<QuerySampleLibraryTrampoline*>(qsl);
   LogSettings default_log_settings;
-  mlperf::StartTest(sut_cast, qsl_cast, test_settings, default_log_settings);
+  mlperf::StartTest(sut_cast, qsl_cast, test_settings, default_log_settings,
+                    audit_config_filename);
 }
 
 void StartTestWithLogSettings(uintptr_t sut, uintptr_t qsl,
                               mlperf::TestSettings test_settings,
-                              mlperf::LogSettings log_settings) {
+                              mlperf::LogSettings log_settings,
+                              const std::string& audit_config_filename) {
   pybind11::gil_scoped_release gil_releaser;
   SystemUnderTestTrampoline* sut_cast =
       reinterpret_cast<SystemUnderTestTrampoline*>(sut);
   QuerySampleLibraryTrampoline* qsl_cast =
       reinterpret_cast<QuerySampleLibraryTrampoline*>(qsl);
-  mlperf::StartTest(sut_cast, qsl_cast, test_settings, log_settings);
+  mlperf::StartTest(sut_cast, qsl_cast, test_settings, log_settings,
+                    audit_config_filename);
 }
 
 using ResponseCallback = std::function<void(QuerySampleResponse*)>;
@@ -382,10 +385,16 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
 
   m.def("StartTest", &py::StartTest,
         "Run tests on a SUT created by ConstructSUT() with the provided QSL. "
-        "Uses default log settings.");
+        "Uses default log settings.",
+        pybind11::arg("sut"), pybind11::arg("qsl"),
+        pybind11::arg("test_settings"),
+        pybind11::arg("audit_config_filename") = "audit.config");
   m.def("StartTestWithLogSettings", &py::StartTestWithLogSettings,
         "Run tests on a SUT created by ConstructSUT() with the provided QSL. "
-        "Accepts custom log settings.");
+        "Accepts custom log settings.",
+        pybind11::arg("sut"), pybind11::arg("qsl"),
+        pybind11::arg("test_settings"), pybind11::arg("log_settings"),
+        pybind11::arg("audit_config_filename") = "audit.config");
   m.def("QuerySamplesComplete", &py::QuerySamplesComplete,
         "Called by the SUT to indicate that samples from some combination of"
         "IssueQuery calls have finished.",

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1516,7 +1516,8 @@ struct RunFunctions {
 
 void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,
-               const LogSettings& log_settings) {
+               const LogSettings& log_settings,
+               const std::string& audit_config_filename) {
   GlobalLogger().StartIOThread();
 
   const std::string test_date_time = CurrentDateTimeISO8601();
@@ -1557,7 +1558,6 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
 
   TestSettings test_settings = requested_settings;
   // Look for Audit Config file to override TestSettings during audit
-  const std::string audit_config_filename = "audit.config";
   if (FileExists(audit_config_filename)) {
     LogDetail([](AsyncDetail& detail) {
 #if USE_NEW_LOGGING_FORMAT

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -69,7 +69,8 @@ void QuerySamplesComplete(QuerySampleResponse* responses, size_t response_count,
 ///
 void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,
-               const LogSettings& log_settings);
+               const LogSettings& log_settings,
+               const std::string& audit_config_filename);
 
 ///
 /// \brief Aborts the running test.

--- a/vision/classification_and_detection/python/main.py
+++ b/vision/classification_and_detection/python/main.py
@@ -207,6 +207,8 @@ def get_args():
     parser.add_argument("--mlperf_conf", default="../../mlperf.conf", help="mlperf rules config")
     # file for user LoadGen settings such as target QPS
     parser.add_argument("--user_conf", default="user.conf", help="user config for user LoadGen settings such as target QPS")
+    # file for LoadGen audit settings
+    parser.add_argument("--audit_conf", default="audit.config", help="config for LoadGen audit settings")
 
     # below will override mlperf rules compliant settings - don't use for official submission
     parser.add_argument("--time", type=int, help="time to scan in seconds")
@@ -459,6 +461,8 @@ def main():
         log.error("{} not found".format(user_conf))
         sys.exit(1)
 
+    audit_config = os.path.abspath(args.audit_conf)
+
     if args.output:
         output_dir = os.path.abspath(args.output)
         os.makedirs(output_dir, exist_ok=True)
@@ -541,7 +545,7 @@ def main():
     result_dict = {"good": 0, "total": 0, "scenario": str(scenario)}
     runner.start_run(result_dict, args.accuracy)
 
-    lg.StartTestWithLogSettings(sut, qsl, settings, log_settings)
+    lg.StartTestWithLogSettings(sut, qsl, settings, log_settings, audit_config)
 
     if not last_timeing:
         last_timeing = runner.result_timing


### PR DESCRIPTION
Fixes #862 
Solution to this  [request](https://github.com/mlcommons/inference/issues/862#issuecomment-790627797)
- Modify StartTest function to receive the parameter audit_config_filename indicating the location of the `audit.config` file.
- Modify the python and c++ APIs to accept the audit_config_filename as a parameter and set its value to `"audit.config"` by default. This emulates how LoadGen previously worked and assures backwards compatibility.