### PR TITLE
Fixed Bug: Default value of audit_config_filename

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1535,7 +1535,7 @@ struct RunFunctions {
 void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,
                const LogSettings& log_settings,
-               const std::string& audit_config_filename) {
+               const std::string audit_config_filename) {
   GlobalLogger().StartIOThread();
 
   const std::string test_date_time = CurrentDateTimeISO8601();

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <functional>
+#include <string>
 
 /// \brief Contains the loadgen API.
 namespace mlperf {
@@ -70,7 +71,7 @@ void QuerySamplesComplete(QuerySampleResponse* responses, size_t response_count,
 void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,
                const LogSettings& log_settings,
-               const std::string& audit_config_filename);
+               const std::string audit_config_filename = "audit.config");
 
 ///
 /// \brief Aborts the running test.


### PR DESCRIPTION
Fix issue #1040 
Add default value of audit_config_filename for every call of StartTest