### PR TITLE
Fixed singlestream latency type to handle sub millisecond target latencies

### DIFF
--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -151,7 +151,7 @@ struct TestSettings {
   /**@{*/
   /// \brief A hint used by the loadgen to pre-generate enough samples to
   ///        meet the minimum test duration.
-  uint64_t single_stream_expected_latency_ns = 1000000;
+  double single_stream_expected_latency_ns = 1000000;
   /// \brief The latency percentile reported as the final result.
   double single_stream_target_latency_percentile = 0.90;
   /**@}*/

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -677,8 +677,8 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   // keys that apply to SingleStream
   lookupkv(model, "SingleStream", "target_latency_percentile", nullptr,
            &single_stream_target_latency_percentile, 0.01);
-  lookupkv(model, "SingleStream", "target_latency",
-           &single_stream_expected_latency_ns, nullptr, 1000 * 1000);
+  lookupkv(model, "SingleStream", "target_latency", nullptr,
+           &single_stream_expected_latency_ns, 1000 * 1000);
 
   // keys that apply to MultiStream
   lookupkv(model, "MultiStream", "target_latency_percentile", nullptr,


### PR DESCRIPTION
Currently loadgen fails when target_latency for singlestream scenario is given as a fraction of a millisecond. This change will make loadgen handle lower than 1 millisecond latencies for singlestream scenario. 