### PR TITLE
Log number of queries and overlatency queries

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1017,9 +1017,9 @@ void PerformanceSummary::LogDetail(AsyncDetail& detail) {
   MLPERF_LOG(detail, "early_stopping_result", early_stopping_recommendation);
 
   // Report number of queries
-  MLPERF_LOG(detail, "query_count", std::to_string(query_count));
+  MLPERF_LOG(detail, "result_query_count", std::to_string(query_count));
   if (settings.scenario == TestScenario::Server) {
-    MLPERF_LOG(detail, "overlatency_query_count",
+    MLPERF_LOG(detail, "result_overlatency_query_count",
                std::to_string(overlatency_query_count));
   }
 


### PR DESCRIPTION
Fixes #977 
- Count the number of overlatency queries for server scenario: In this case samples per query is always 1, sample_latencies are used as the query latencies

- Log the number of queries for all scenarios and the number of overlatency queries for the server scenario