### PR TITLE
Submission checker changes for early stopping

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1013,6 +1013,8 @@ void PerformanceSummary::LogDetail(AsyncDetail& detail) {
     }
     MLPERF_LOG(detail, "result_invalid_reason", recommendation);
   }
+  std::replace(early_stopping_recommendation.begin(),
+               early_stopping_recommendation.end(), '\n', ' ');
   MLPERF_LOG(detail, "early_stopping_result", early_stopping_recommendation);
 
   // Report number of queries


### PR DESCRIPTION
Fix #1051. Add some changes to submission checker to support early stopping:

- Change variable `RESULT_FIELD_NEW`. This reflects the early stopping result for the singlestream and multstream scenarios.
- If the model/scenario uses early stopping, it checks if the early stopping criteria was met. Otherwise it checks the previous latency criteria
- Extract min_queries from detail_logs if it is using early stopping.
- Infer Multistream from Singlestream using the early stopping results
- Remove `\n` when loadgen reports `early_stopping_result`