### PR TITLE
Fix build error

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -614,7 +614,6 @@ void PerformanceSummary::ProcessLatencies() {
   // Calculate per-query stats.
   size_t query_count = pr.queries_issued;
   assert(pr.query_latencies.size() == query_count);
-  assert(pr.query_intervals.size() == query_count);
   std::sort(pr.query_latencies.begin(), pr.query_latencies.end());
   QuerySampleLatency accumulated_query_latency = 0;
   for (auto latency : pr.query_latencies) {


### PR DESCRIPTION
Fix #1062 
Remove non-existing variable `pr.query_intervals`. Not used anywhere else. @arjunsuresh @rnaidu02 