### PR TITLE
Fix: sample_concatenate_permutation affects unwanted scenarios 

### DIFF
--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -675,9 +675,9 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
 
   // keys that apply to Offline
   lookupkv(model, "Offline", "target_qps", 0, &offline_expected_qps);
-  if (lookupkv(model, "Offline", "sample_concatenate_permutation", &val, nullptr))
-    sample_concatenate_permutation = (val == 0) ? false : true;
-  
+  if (lookupkv(model, scenario, "sample_concatenate_permutation", &val, nullptr))
+    sample_concatenate_permutation = 
+      (val == 1) && scenario == "Offline" ? true : false;
 
   return 0;
 }

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -677,7 +677,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   lookupkv(model, "Offline", "target_qps", 0, &offline_expected_qps);
   if (lookupkv(model, scenario, "sample_concatenate_permutation", &val, nullptr))
     sample_concatenate_permutation = 
-      (val == 1) && scenario == "Offline" ? true : false;
+      (val == 1) && (scenario == "Offline") ? true : false;
 
   return 0;
 }


### PR DESCRIPTION
Current way of consuming parameter `sample_concatenate_permutation` unfortunately impacts other than `Offline` scenario because `sample_concatenate_permutation` is used in populating samples regardless of what the current scenario is.

`mlperf.conf` or `user.conf` can specify Offline scenario by setting like `3d-unet.Offline.sample_concatenate_permutation`. The issue is, this `*.conf` can hold parameters for all kinds of network/scenario combination, although the current run might only target one specific network/scenario.

If current scenario is `SingleStream`, the expectation is `*.Offline.sample_concatenate_permutation` is not impacting the LoadGen behavior. But since `*.conf` contains `3d-unet.Offline.sample_concatenate_permutation`, internal representation of this parameter `sample_concatenate_permutation` shall be set to true, and affect the LoadGen's sample population for `SingleStream`.

This fix addresses the above issue. Alternatively, we might be able to rewrite the code such that internal boolean variable `sample_concatenate_permutation` is only consumed in the `Offline` scenario. This might need wider change. So for the sake of the v2.0 submission timeline, this simple fix would do the job.