### PR TITLE
Fixing Issue #1082: EqualIssueMode support for 3DUNet SingleStream

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -182,6 +182,25 @@ auto SampleDistribution<TestMode::PerformanceOnly>(size_t sample_count,
              auto& gen) mutable { return dist(gen); };
 }
 
+/// \brief SampleDistribution for 3D-UNet SingleStream, for v2.0
+// FIXME: meant for 3D UNet SingleStream only at the moment but the logic should work for others
+// TODO: consolidate the distribution generator after v2.0 
+auto SampleDistributionEqualIssue(size_t sample_count, size_t set_size, std::mt19937* rng) {
+  std::vector<size_t> indices;
+  std::vector<size_t> shuffle_indices;
+  for (size_t i = 0; i < set_size; ++i) {
+    shuffle_indices.push_back(i);
+  }
+  for (size_t j = 0; j < sample_count; j += set_size) {
+    std::shuffle(shuffle_indices.begin(), shuffle_indices.end(), *rng);
+    indices.insert(indices.end(), shuffle_indices.begin(), shuffle_indices.end());
+  }
+  return [indices = std::move(indices), i = size_t(0)](auto& /*gen*/) mutable {
+    return indices.at((i++)%indices.size());
+  };
+}
+
+
 /// \brief Generates queries for the requested settings, templated by
 /// scenario and mode.
 /// \todo Make GenerateQueries faster.
@@ -243,17 +262,27 @@ std::vector<QueryMetadata> GenerateQueries(
   auto sample_distribution_unique = SampleDistribution<TestMode::AccuracyOnly>(
       loaded_sample_set.sample_distribution_end, sample_stride, &sample_rng);
 
+  // FIXME: Only used for v2.0 3D-UNet KiTS19 SingleStream
+  // TODO: Need to consolidate the code for any generic usage after v2.0
+  auto sample_distribution_equal_issue =
+      SampleDistributionEqualIssue(min_queries,
+                                   loaded_samples.size(),
+                                   &sample_rng);
+
   auto schedule_distribution =
       ScheduleDistribution<scenario>(settings.target_qps);
 
   // When sample_concatenate_permutation is turned on, pad to a multiple of the
   // complete dataset to ensure complete fairness.
+  // FIXME: Only override this for Offline; fix after v2.0
   if (settings.sample_concatenate_permutation &&
+      scenario == TestScenario::Offline &&
       samples_per_query % loaded_samples.size() != 0) {
     size_t pad_size =
         (loaded_samples.size() - samples_per_query % loaded_samples.size());
     samples_per_query += pad_size;
   }
+
   std::vector<QuerySampleIndex> samples(samples_per_query);
   std::chrono::nanoseconds timestamp(0);
   std::chrono::nanoseconds prev_timestamp(0);
@@ -307,12 +336,18 @@ std::vector<QueryMetadata> GenerateQueries(
         }
       }
     } else {
+      // FIXME: only used for v2.0 3D-UNet KiTS19 SingleStream
+      // TODO: consolidate after v2.0
+      auto equal_issue = settings.sample_concatenate_permutation &&
+                         scenario == TestScenario::SingleStream;
       for (auto& s : samples) {
         s = loaded_samples[settings.performance_issue_unique
-                               ? sample_distribution_unique(sample_rng)
+                           ? sample_distribution_unique(sample_rng)
                            : settings.performance_issue_same
-                               ? same_sample
-                               : sample_distribution(sample_rng)];
+                            ? same_sample
+                            : equal_issue
+                              ? sample_distribution_equal_issue(sample_rng)
+                              : sample_distribution(sample_rng)];
       }
     }
     queries.emplace_back(samples, timestamp, response_delegate, sequence_gen);
@@ -390,6 +425,7 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
       settings.target_qps * settings.min_duration.count() / 1000;
   uint64_t minimum_queries =
       settings.min_query_count * settings.samples_per_query;
+
   if (scenario != TestScenario::Offline) {
     expected_queries *= settings.samples_per_query;
   } else {

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -187,7 +187,8 @@ auto SampleDistribution<TestMode::PerformanceOnly>(size_t sample_count,
 // TODO: consolidate the distribution generator after v2.0 
 auto SampleDistributionEqualIssue(size_t sample_count, size_t set_size, std::mt19937* rng) {
   std::vector<size_t> indices;
-  std::vector<size_t> shuffle_indices;
+  std::vector<size_t> shuffle_indices(set_size);
+  std::iota(shuffle_indices.begin(), shuffle_indices.end(), 0);
   for (size_t i = 0; i < set_size; ++i) {
     shuffle_indices.push_back(i);
   }

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -146,6 +146,22 @@ TestSettingsInternal::TestSettingsInternal(
     target_duration = std::chrono::milliseconds(0);
   }
 
+  // FIXME: Only do this for 3D-UNet SingleStream, for v2.0
+  // TODO: consolidate after v2.0
+  // make min_queries to be multiple of performance_sample_count
+  // performance_sample_count == 0 makes it to be equal to loaded_samples.size()
+  if (sample_concatenate_permutation &&
+      requested.scenario == TestScenario::SingleStream) {
+    // set slack larger for 3D-UNet KiTS19 distribution, i.e. 50% latency << 90% latency
+    constexpr double kSlack = 2.0;
+    uint64_t expected_queries = kSlack * DurationToSeconds(target_duration) * target_qps;
+    min_query_count = min_query_count > expected_queries 
+                      ? min_query_count
+                      : expected_queries;
+    min_query_count += 
+        qsl_performance_sample_count - (min_query_count  % qsl_performance_sample_count);
+  }
+
   min_sample_count = min_query_count * samples_per_query;
 
   // Validate TestSettings
@@ -647,6 +663,8 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
            &performance_issue_same_index, nullptr);
   lookupkv(model, scenario, "performance_sample_count_override",
            &performance_sample_count_override, nullptr);
+  if (lookupkv(model, scenario, "sample_concatenate_permutation", &val, nullptr))
+    sample_concatenate_permutation = (val == 1) ? true : false;
 
   // keys that apply to SingleStream
   lookupkv(model, "SingleStream", "target_latency_percentile", nullptr,
@@ -675,9 +693,6 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
 
   // keys that apply to Offline
   lookupkv(model, "Offline", "target_qps", 0, &offline_expected_qps);
-  if (lookupkv(model, scenario, "sample_concatenate_permutation", &val, nullptr))
-    sample_concatenate_permutation = 
-      (val == 1) && (scenario == "Offline") ? true : false;
 
   return 0;
 }

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -675,9 +675,9 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
 
   // keys that apply to Offline
   lookupkv(model, "Offline", "target_qps", 0, &offline_expected_qps);
-  if (lookupkv(model, "Offline", "sample_concatenate_permutation", &val, nullptr))
-    sample_concatenate_permutation = (val == 0) ? false : true;
-  
+  if (lookupkv(model, scenario, "sample_concatenate_permutation", &val, nullptr))
+    sample_concatenate_permutation = 
+      (val == 1) && (scenario == "Offline") ? true : false;
 
   return 0;
 }

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -11,6 +11,7 @@ ssd-resnet34.*.performance_sample_count_override = 64
 bert.*.performance_sample_count_override = 10833
 dlrm.*.performance_sample_count_override = 204800
 rnnt.*.performance_sample_count_override = 2513
+# set to 0 to let entire sample set to be performance sample
 3d-unet.*.performance_sample_count_override = 0
 
 # Set seeds. The seeds will be distributed two weeks before the submission.
@@ -30,7 +31,9 @@ rnnt.*.performance_sample_count_override = 2513
 *.MultiStream.min_duration = 600000
 *.MultiStream.min_query_count = 270336
 ssd-resnet34.MultiStream.target_latency = 528
-3d-unet.Offline.sample_concatenate_permutation = 1
+
+# 3D-UNet uses equal issue mode
+3d-unet.*.sample_concatenate_permutation = 1
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99


### PR DESCRIPTION
This fix adds the equal issue mode support; it's currently limited to only SingleStream scenario, and the `mlperf.conf` only enables it for 3D-UNet as a default setting. 

I have tried not to touch anything other than:
* SingleStream scenario may only choose it
* Only enabled when `sample_concatenate_permutation` is set (which is only set for 3D-UNet)
* `performance_sample_count_override` should set to 0 to let entire sample set is loaded in for shuffle

The bottom two parameters are reusing what's already introduced for 3D-UNet Offline from #1032. This would help consolidating the code later.

![Screenshot 2022-02-09 151148](https://user-images.githubusercontent.com/83969361/153290828-26a0d7ff-fde7-49e3-851b-fd4aecd3c313.png)

