### PR TITLE
Update submission_checker auto-match

### DIFF
--- a/tools/submission/submission-checker.py
+++ b/tools/submission/submission-checker.py
@@ -687,7 +687,7 @@ class Config():
             model = "ssd-small"
         elif "mobilenet" in model:
             model = "mobilenet"
-        elif "efficientnet" in model:
+        elif "efficientnet" in model or "resnet50" in model:
             model = "resnet"
         elif "rcnn" in model:
             model = "ssd-small"


### PR DESCRIPTION
Allows resnet50 submissions with name variants to be automatically matched to the correct model.  Previously, achieving this effect required appending 'efficientnet' which is no longer appropriate.