### PR TITLE
Replace `SAME` and `VALID` with `same` and `valid`

### DIFF
--- a/vision/classification_and_detection/python/models/ssd_mobilenet_v1.py
+++ b/vision/classification_and_detection/python/models/ssd_mobilenet_v1.py
@@ -16,7 +16,7 @@ def conv_bn(inp, oup, stride):
     return nn.Sequential(
         OrderedDict(
             [
-                ("0", Conv2d_tf(inp, oup, 3, stride, padding="SAME", bias=False)),
+                ("0", Conv2d_tf(inp, oup, 3, stride, padding="same", bias=False)),
                 ("0/BatchNorm", BiasAdd(oup)),
                 ("0/ReLU", nn.ReLU6(inplace=True)),
             ]
@@ -31,7 +31,7 @@ def conv_dw(inp, oup, stride):
                 (
                     "depthwise",
                     Conv2d_tf(
-                        inp, inp, 3, stride, padding="SAME", groups=inp, bias=False
+                        inp, inp, 3, stride, padding="same", groups=inp, bias=False
                     ),
                 ),
                 ("depthwise/BatchNorm", BatchNorm2d(inp)),
@@ -105,7 +105,7 @@ class Block(nn.Sequential):
             nn.Conv2d(in_channels, out_channels=mid_channels, kernel_size=1),
             nn.ReLU6(),
             Conv2d_tf(
-                mid_channels, out_channels, kernel_size=3, stride=2, padding="SAME"
+                mid_channels, out_channels, kernel_size=3, stride=2, padding="same"
             ),
             nn.ReLU6(),
         )

--- a/vision/classification_and_detection/python/models/utils.py
+++ b/vision/classification_and_detection/python/models/utils.py
@@ -44,7 +44,7 @@ class Conv2d_tf(nn.Conv2d):
 
     def __init__(self, *args, **kwargs):
         super(Conv2d_tf, self).__init__(*args, **kwargs)
-        self.padding = kwargs.get("padding", "SAME")
+        self.padding = kwargs.get("padding", "same")
 
     def _compute_padding(self, input, dim):
         input_size = input.size(dim + 2)
@@ -60,7 +60,7 @@ class Conv2d_tf(nn.Conv2d):
 
     def forward(self, input):
         #import pdb; pdb.set_trace()
-        if self.padding == "VALID":
+        if self.padding == "valid":
             return F.conv2d(
                 input,
                 self.weight,


### PR DESCRIPTION
The `padding` argument of PyTorch `Conv2d` has to be `same` or `valid`, not `SAME` or `VALID`.

https://github.com/pytorch/pytorch/blob/f6e7a2ab640d96667a414c9ddc925c1d146aa0ba/torch/nn/modules/conv.py#L87-L92

```python
        valid_padding_strings = {'same', 'valid'}
        if isinstance(padding, str):
            if padding not in valid_padding_strings:
                raise ValueError(
                    "Invalid padding string {!r}, should be one of {}".format(
                        padding, valid_padding_strings))
```

https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html

> `padding` controls the amount of padding applied to the input. It can be either a string {‘valid’, ‘same’} or a tuple of ints giving the amount of implicit padding applied on both sides.

resolve: #971 