### PR TITLE
Add open images scripts

### DIFF
--- a/vision/classification_and_detection/python/openimages.py
+++ b/vision/classification_and_detection/python/openimages.py
@@ -1,0 +1,119 @@
+import json
+import logging
+import os
+import time
+
+import cv2
+import numpy as np
+from pycocotools.cocoeval import COCOeval
+import pycoco
+import dataset
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("coco")
+
+
+class OpenImages(dataset.Dataset):
+    def __init__(self, data_path, image_list, name, use_cache=0, image_size=None,
+                 image_format="NHWC", pre_process=None, count=None, cache_dir=None,use_label_map=False):
+        super().__init__()
+        self.image_size = image_size
+        self.image_list = []
+        self.label_list = []
+        self.image_ids = []
+        self.image_sizes = []
+        self.count = count
+        self.use_cache = use_cache
+        self.data_path = data_path
+        self.pre_process = pre_process
+        self.use_label_map=use_label_map
+        if not cache_dir:
+            cache_dir = os.getcwd()
+        self.cache_dir = os.path.join(cache_dir, "preprocessed", name, image_format)
+        # input images are in HWC
+        self.need_transpose = True if image_format == "NCHW" else False
+        not_found = 0 
+        empty_80catageories = 0
+        if image_list is None:
+            # by default look for val_map.txt
+            image_list = os.path.join(data_path, "annotations/openimages-mlperf.json")
+        self.annotation_file = image_list
+        if self.use_label_map:
+            # for pytorch
+            label_map = {}
+            with open(self.annotation_file) as fin:
+                annotations = json.load(fin)
+            for cnt, cat in enumerate(annotations["categories"]):
+                label_map[cat["id"]] = cnt + 1
+
+        os.makedirs(self.cache_dir, exist_ok=True)
+        start = time.time()
+        images = {}
+        with open(image_list, "r") as f:
+            openimages = json.load(f)
+        for i in openimages["images"]:
+            images[i["id"]] = {"file_name": i["file_name"],
+                               "height": i["height"],
+                               "width": i["width"],
+                               "bbox": [],
+                               "category": []}
+        for a in openimages["annotations"]:
+            i = images.get(a["image_id"])
+            if i is None:
+                continue
+            catagory_ids = label_map[a.get("category_id")] if self.use_label_map else a.get("category_id")
+            i["category"].append(catagory_ids)
+            i["bbox"].append(a.get("bbox"))
+
+        for image_id, img in images.items():
+            image_name = os.path.join("validation", "data", img["file_name"])
+            src = os.path.join(data_path, image_name)
+            if not os.path.exists(src):
+                # if the image does not exists ignore it
+                not_found += 1
+                continue
+            if len(img["category"])==0 and self.use_label_map: 
+                #if an image doesn't have any of the 81 categories in it    
+                empty_80catageories += 1 #should be 48 images - thus the validation sert has 4952 images
+                continue 
+
+            os.makedirs(os.path.dirname(os.path.join(self.cache_dir, image_name)), exist_ok=True)
+            dst = os.path.join(self.cache_dir, image_name)
+            if not os.path.exists(dst + ".npy"):
+                # cache a preprocessed version of the image
+                img_org = cv2.imread(src)
+                processed = self.pre_process(img_org, need_transpose=self.need_transpose, dims=self.image_size)
+                np.save(dst, processed)
+
+            self.image_ids.append(image_id)
+            self.image_list.append(image_name)
+            self.image_sizes.append((img["height"], img["width"]))
+            self.label_list.append((img["category"], img["bbox"]))
+
+            # limit the dataset if requested
+            if self.count and len(self.image_list) >= self.count:
+                break
+
+        time_taken = time.time() - start
+        if not self.image_list:
+            log.error("no images in image list found")
+            raise ValueError("no images in image list found")
+        if not_found > 0:
+            log.info("reduced image list, %d images not found", not_found)
+        if empty_80catageories > 0:
+            log.info("reduced image list, %d images without any of the 80 categories", empty_80catageories)
+
+        log.info("loaded {} images, cache={}, took={:.1f}sec".format(
+            len(self.image_list), use_cache, time_taken))
+
+        self.label_list = np.array(self.label_list)
+
+    def get_item(self, nr):
+        """Get image by number in the list."""
+        dst = os.path.join(self.cache_dir, self.image_list[nr])
+        img = np.load(dst + ".npy")
+        return img, self.label_list[nr]
+
+    def get_item_loc(self, nr):
+        src = os.path.join(self.data_path, self.image_list[nr])
+        return src

--- a/vision/classification_and_detection/tools/accuracy-openimages.py
+++ b/vision/classification_and_detection/tools/accuracy-openimages.py
@@ -1,0 +1,117 @@
+"""
+Tool to calculate accuracy for loadgen accuracy output found in mlperf_log_accuracy.json
+We assume that loadgen's query index is in the same order as
+the images in coco's annotations/instances_val2017.json.
+"""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import json
+import os
+
+import numpy as np
+
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+
+# pylint: disable=missing-docstring
+
+def get_args():
+    """Parse commandline."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mlperf-accuracy-file", required=True, help="path to mlperf_log_accuracy.json")
+    parser.add_argument("--openimages-dir", required=True, help="openimages directory")
+    parser.add_argument("--verbose", action="store_true", help="verbose messages")
+    parser.add_argument("--output-file", default="openimages-results.json", help="path to output file")
+    parser.add_argument("--use-inv-map", action="store_true", help="use inverse label map")
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = get_args()
+
+    cocoGt = COCO(os.path.join(args.openimages_dir, "annotations/openimages-mlperf.json"))
+
+    if args.use_inv_map:
+        inv_map = [0] + cocoGt.getCatIds() # First label in inv_map is not used
+
+    with open(args.mlperf_accuracy_file, "r") as f:
+        results = json.load(f)
+
+    detections = []
+    image_ids = set()
+    seen = set()
+    no_results = 0
+    image_map = cocoGt.dataset["images"]
+
+    for j in results:
+        idx = j['qsl_idx']
+        # de-dupe in case loadgen sends the same image multiple times
+        if idx in seen:
+            continue
+        seen.add(idx)
+
+        # reconstruct from mlperf accuracy log
+        # what is written by the benchmark is an array of float32's:
+        # id, box[0], box[1], box[2], box[3], score, detection_class
+        # note that id is a index into instances_val2017.json, not the actual image_id
+        data = np.frombuffer(bytes.fromhex(j['data']), np.float32)
+        if len(data) < 7:
+            # handle images that had no results
+            image = image_map[idx]
+            # by adding the id to image_ids we make pycoco aware of the no-result image
+            image_ids.add(image["id"])
+            no_results += 1
+            if args.verbose:
+                print("no results: {}, idx={}".format(image["coco_url"], idx))
+            continue
+
+        for i in range(0, len(data), 7):
+            image_idx, ymin, xmin, ymax, xmax, score, label = data[i:i + 7]
+            image = image_map[idx]
+            image_idx = int(image_idx)
+            if image_idx != idx:
+                print("ERROR: loadgen({}) and payload({}) disagree on image_idx".format(idx, image_idx))
+            image_id = image["id"]
+            height, width = image["height"], image["width"]
+            ymin *= height
+            xmin *= width
+            ymax *= height
+            xmax *= width
+            loc = os.path.join(args.openimages_dir, "validation/data", image["file_name"])
+            label = int(label)
+            if args.use_inv_map:
+                label = inv_map[label]
+            # pycoco wants {imageID,x1,y1,w,h,score,class}
+            detections.append({
+                "image_id": image_id,
+                "image_loc": loc,
+                "category_id": label,
+                "bbox": [float(xmin), float(ymin), float(xmax - xmin), float(ymax - ymin)],
+                "score": float(score)})
+            image_ids.add(image_id)
+
+    with open(args.output_file, "w") as fp:
+        json.dump(detections, fp, sort_keys=True, indent=4)
+
+    cocoDt = cocoGt.loadRes(args.output_file) # Load from file to bypass error with Python3
+    cocoEval = COCOeval(cocoGt, cocoDt, iouType='bbox')
+    cocoEval.params.imgIds = list(image_ids)
+    cocoEval.evaluate()
+    cocoEval.accumulate()
+    cocoEval.summarize()
+
+    print("mAP={:.3f}%".format(100. * cocoEval.stats[0]))
+    if args.verbose:
+        print("found {} results".format(len(results)))
+        print("found {} images".format(len(image_ids)))
+        print("found {} images with no results".format(no_results))
+        print("ignored {} dupes".format(len(results) - len(seen)))
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/classification_and_detection/tools/openimages.py
+++ b/vision/classification_and_detection/tools/openimages.py
@@ -1,0 +1,58 @@
+import os
+import json
+import argparse
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        description="Download OpenImages using FiftyOne", add_help=True
+    )
+    parser.add_argument(
+        "--dataset-dir", default="/open-images-v6", help="dataset download location"
+    )
+    parser.add_argument(
+        "--classes",
+        default=None,
+        nargs="+",
+        type=str,
+        help="Classes to download. default to all classes",
+    )
+    parser.add_argument(
+        "--output-labels",
+        default="labels.json",
+        type=str,
+        help="Classes to download. default to all classes",
+    )
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = get_args()
+    print("Downloading open-images dataset ...")
+    dataset = foz.load_zoo_dataset(
+        name="open-images-v6",
+        classes=args.classes,
+        split="validation",
+        label_types="detections",
+        dataset_name="open-images",
+        dataset_dir=args.dataset_dir,
+    )
+
+    print("Converting dataset to coco format ...")
+    output_fname = os.path.join(args.dataset_dir, "annotations", args.output_labels)
+    dataset.export(
+        labels_path=output_fname,
+        dataset_type=fo.types.COCODetectionDataset,
+        label_field="detections",
+        classes=args.classes,
+    )
+    # Add iscrowd label to openimages annotations
+    with open(output_fname) as fp:
+        labels = json.load(fp)
+    for annotation in labels["annotations"]:
+        annotation["iscrowd"] = int(annotation["IsGroupOf"])
+    with open(output_fname, "w") as fp:
+        json.dump(labels, fp)

--- a/vision/classification_and_detection/tools/openimages_mlperf.sh
+++ b/vision/classification_and_detection/tools/openimages_mlperf.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+: "${DATASET_PATH:=../open-images-v6-mlperf}"
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -d | --dataset-path  )        shift
+                                      DATASET_PATH=$1
+                                      ;;
+    esac
+    shift
+done
+
+MLPERF_CLASSES=('Airplane' 'Antelope' 'Apple' 'Backpack' 'Balloon' 'Banana'
+'Barrel' 'Baseball bat' 'Baseball glove' 'Bee' 'Beer' 'Bench' 'Bicycle'
+'Bicycle helmet' 'Bicycle wheel' 'Billboard' 'Book' 'Bookcase' 'Boot'
+'Bottle' 'Bowl' 'Bowling equipment' 'Box' 'Boy' 'Brassiere' 'Bread'
+'Broccoli' 'Bronze sculpture' 'Bull' 'Bus' 'Bust' 'Butterfly' 'Cabinetry'
+'Cake' 'Camel' 'Camera' 'Candle' 'Candy' 'Cannon' 'Canoe' 'Carrot' 'Cart'
+'Castle' 'Cat' 'Cattle' 'Cello' 'Chair' 'Cheese' 'Chest of drawers' 'Chicken'
+'Christmas tree' 'Coat' 'Cocktail' 'Coffee' 'Coffee cup' 'Coffee table' 'Coin'
+'Common sunflower' 'Computer keyboard' 'Computer monitor' 'Convenience store'
+'Cookie' 'Countertop' 'Cowboy hat' 'Crab' 'Crocodile' 'Cucumber' 'Cupboard'
+'Curtain' 'Deer' 'Desk' 'Dinosaur' 'Dog' 'Doll' 'Dolphin' 'Door' 'Dragonfly'
+'Drawer' 'Dress' 'Drum' 'Duck' 'Eagle' 'Earrings' 'Egg (Food)' 'Elephant'
+'Falcon' 'Fedora' 'Flag' 'Flowerpot' 'Football' 'Football helmet' 'Fork'
+'Fountain' 'French fries' 'French horn' 'Frog' 'Giraffe' 'Girl' 'Glasses'
+'Goat' 'Goggles' 'Goldfish' 'Gondola' 'Goose' 'Grape' 'Grapefruit' 'Guitar'
+'Hamburger' 'Handbag' 'Harbor seal' 'Headphones' 'Helicopter' 'High heels'
+'Hiking equipment' 'Horse' 'House' 'Houseplant' 'Human arm' 'Human beard'
+'Human body' 'Human ear' 'Human eye' 'Human face' 'Human foot' 'Human hair'
+'Human hand' 'Human head' 'Human leg' 'Human mouth' 'Human nose' 'Ice cream'
+'Jacket' 'Jeans' 'Jellyfish' 'Juice' 'Kitchen & dining room table' 'Kite'
+'Lamp' 'Lantern' 'Laptop' 'Lavender (Plant)' 'Lemon' 'Light bulb' 'Lighthouse'
+'Lily' 'Lion' 'Lipstick' 'Lizard' 'Man' 'Maple' 'Microphone' 'Mirror'
+'Mixing bowl' 'Mobile phone' 'Monkey' 'Motorcycle' 'Muffin' 'Mug' 'Mule'
+'Mushroom' 'Musical keyboard' 'Necklace' 'Nightstand' 'Office building'
+'Orange' 'Owl' 'Oyster' 'Paddle' 'Palm tree' 'Parachute' 'Parrot' 'Pen'
+'Penguin' 'Personal flotation device' 'Piano' 'Picture frame' 'Pig' 'Pillow'
+'Pizza' 'Plate' 'Platter' 'Porch' 'Poster' 'Pumpkin' 'Rabbit' 'Rifle'
+'Roller skates' 'Rose' 'Salad' 'Sandal' 'Saucer' 'Saxophone' 'Scarf' 'Sea lion'
+'Sea turtle' 'Sheep' 'Shelf' 'Shirt' 'Shorts' 'Shrimp' 'Sink' 'Skateboard'
+'Ski' 'Skull' 'Skyscraper' 'Snake' 'Sock' 'Sofa bed' 'Sparrow' 'Spider' 'Spoon'
+'Sports uniform' 'Squirrel' 'Stairs' 'Stool' 'Strawberry' 'Street light'
+'Studio couch' 'Suit' 'Sun hat' 'Sunglasses' 'Surfboard' 'Sushi' 'Swan'
+'Swimming pool' 'Swimwear' 'Tank' 'Tap' 'Taxi' 'Tea' 'Teddy bear' 'Television'
+'Tent' 'Tie' 'Tiger' 'Tin can' 'Tire' 'Toilet' 'Tomato' 'Tortoise' 'Tower'
+'Traffic light' 'Train' 'Tripod' 'Truck' 'Trumpet' 'Umbrella' 'Van' 'Vase'
+'Vehicle registration plate' 'Violin' 'Wall clock' 'Waste container' 'Watch'
+'Whale' 'Wheel' 'Wheelchair' 'Whiteboard' 'Window' 'Wine' 'Wine glass' 'Woman'
+'Zebra' 'Zucchini')
+
+python openimages.py \
+    --dataset-dir=${DATASET_PATH} \
+    --output-labels="openimages-mlperf.json" \
+    --classes "${MLPERF_CLASSES[@]}"


### PR DESCRIPTION
Add scripts to collect openimages validation dataset that currently have a "friendly to use" license according to the flickr API.
- Scripts for collecting the images were based on the training repo script located [here](https://github.com/mlcommons/training/blob/master/single_stage_detector/scripts/download_openimages_mlperf.sh) and [here](https://github.com/mlcommons/training/blob/master/single_stage_detector/scripts/fiftyone_openimages.py)
- Collects the images that contain at least one of the classes specified by the training script and that MLC has proof of license
- Converts the annotations into the coco format
