### PR TITLE
Remove retinanet from TEST04

### DIFF
--- a/tools/submission/submission-checker.py
+++ b/tools/submission/submission-checker.py
@@ -1847,7 +1847,7 @@ def check_compliance_dir(compliance_dir, model, scenario, config, division, syst
   compliance_acc_pass = True
   test_list = ["TEST01", "TEST04", "TEST05"]
 
-  if model in ["rnnt", "bert-99", "bert-99.9", "dlrm-99", "dlrm-99.9", "3d-unet-99", "3d-unet-99.9"]:
+  if model in ["rnnt", "bert-99", "bert-99.9", "dlrm-99", "dlrm-99.9", "3d-unet-99", "3d-unet-99.9", "retinanet"]:
     test_list.remove("TEST04")
 
   #Check performance of all Tests


### PR DESCRIPTION
retinanet NMS runtime is significantly longer than on the old ssd benchmarks due to the larger number of classes in OpenImages. This runtime varies from sample to sample based on the number of qualified detections. As such, the assumption that TEST04 makes that all samples should have roughly equal computational cost no longer holds for this workload.