### PR TITLE
Remove retinanet from TEST04

### DIFF
--- a/compliance/nvidia/TEST04/README.md
+++ b/compliance/nvidia/TEST04/README.md
@@ -22,6 +22,7 @@ This test is not applicable for the following benchmarks whose performance is de
  2. bert
  3. dlrm
  4. 3d-unet
+ 5. retinanet (while retinanet input images are not variable, computation cost varies significantly due to the variance in qualified detections from the detector heads, which affect the NMS runtime)
 
 ## Scenarios
 

--- a/tools/submission/submission-checker.py
+++ b/tools/submission/submission-checker.py
@@ -1847,7 +1847,7 @@ def check_compliance_dir(compliance_dir, model, scenario, config, division, syst
   compliance_acc_pass = True
   test_list = ["TEST01", "TEST04", "TEST05"]
 
-  if model in ["rnnt", "bert-99", "bert-99.9", "dlrm-99", "dlrm-99.9", "3d-unet-99", "3d-unet-99.9"]:
+  if model in ["rnnt", "bert-99", "bert-99.9", "dlrm-99", "dlrm-99.9", "3d-unet-99", "3d-unet-99.9", "retinanet"]:
     test_list.remove("TEST04")
 
   #Check performance of all Tests


### PR DESCRIPTION
Our recent experience with retinanet is that there is a much larger degree of variance in runtime between the samples, which can cause TEST04 to fail. What happens is that the NMS layer can take significantly longer than on the old ssd benchmarks due to the larger number of classes in OpenImages. The runtime of this layer varies from sample to sample, scaling with the number of qualified detections. As such, the assumption that TEST04 makes that all samples should have roughly equal computational cost no longer holds for this workload.