### PR TITLE
Change for overriding OUTPUT_DIR for reference implementation

### DIFF
--- a/vision/classification_and_detection/run_local.sh
+++ b/vision/classification_and_detection/run_local.sh
@@ -4,7 +4,7 @@ source ./run_common.sh
 
 common_opt="--mlperf_conf ../../mlperf.conf"
 dataset="--dataset-path $DATA_DIR"
-OUTPUT_DIR=`pwd`/output/$name
+OUTPUT_DIR=${OUTPUT_DIR:-`pwd`/output/$name}
 if [ ! -d $OUTPUT_DIR ]; then
     mkdir -p $OUTPUT_DIR
 fi


### PR DESCRIPTION
This change allows results to be output to a custom folder while using the reference implementation. 