### PR TITLE
Add bert-99 and bert-99.9 to the submission-checker model_mapping guess

### DIFF
--- a/tools/submission/submission-checker.py
+++ b/tools/submission/submission-checker.py
@@ -881,6 +881,10 @@ class Config():
       model = "resnet"
     elif "rcnn" in model:
       model = "ssd-small"
+    elif "bert-99.9" in model:
+      model = "bert-99.9"
+    elif "bert-99" in model:
+      model = "bert-99"
     # map again, for example v0.7 does not have mobilenet so it needs to be mapped to resnet
     mlperf_model = self.base["model_mapping"].get(model, model)
     return mlperf_model


### PR DESCRIPTION
Allows models prepended "bert-99" or "bert-99.9" to be mapped to their respective model category similarly to CV models i.e. bert-99_model-A, bert-99_model-B, etc. would be evaluated as bert-99 models.

This was landed on r2.1 before submission [#1202](https://github.com/mlcommons/inference/pull/1202), bringing the changes to master now.