### PR TITLE
Fix docker for vision reference implementation

### DIFF
--- a/vision/classification_and_detection/Dockerfile.cpu
+++ b/vision/classification_and_detection/Dockerfile.cpu
@@ -32,6 +32,8 @@ RUN cd /opt && \
     conda config --set always_yes yes --set changeps1 no
 
 RUN conda install pytorch-cpu torchvision-cpu -c pytorch
+RUN pip install --upgrade pip
+RUN pip install cmake
 RUN pip install future pillow onnx opencv-python-headless tensorflow onnxruntime
 RUN pip install Cython && pip install pycocotools
 RUN cd /tmp && \

--- a/vision/classification_and_detection/Dockerfile.gpu
+++ b/vision/classification_and_detection/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1-cudnn8-devel-ubuntu16.04
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu16.04
 
 ENV PYTHON_VERSION=3.7
 ENV LANG C.UTF-8
@@ -38,7 +38,9 @@ RUN pip install --upgrade pip && \
     ldconfig
 
 RUN conda install pytorch torchvision -c pytorch
-RUN pip install tensorflow onnxruntime-gpu
+RUN conda install tensorflow-gpu
+RUN pip install --upgrade pip
+RUN pip install onnxruntime-gpu
 RUN pip install Cython && pip install pycocotools
 
 

--- a/vision/classification_and_detection/run_and_time.sh
+++ b/vision/classification_and_detection/run_and_time.sh
@@ -4,7 +4,17 @@ source run_common.sh
 
 dockercmd=docker
 if [ $device == "gpu" ]; then
-    runtime="--runtime=nvidia"
+    version=$(docker version -f "{{.Server.Version}}")
+    major_version=$(echo "$version"| cut -d'.' -f 1)
+    minor_version=$(echo "$version"| cut -d'.' -f 2)
+    if [ $major_version -gt 19 ]; then
+        gpus="--gpus all"
+    elif [ $major_version -ge 19 ] && \
+        [ $minor_version -ge 03 ]; then
+        gpus="--gpus all"
+    else
+        gpus="--runtime=nvidia"
+    fi
 fi
 
 # copy the config to cwd so the docker contrainer has access
@@ -20,7 +30,7 @@ docker build  -t $image -f Dockerfile.$device .
 opts="--mlperf_conf ./mlperf.conf --profile $profile $common_opt --model $model_path \
     --dataset-path $DATA_DIR --output $OUTPUT_DIR $extra_args $EXTRA_OPS $@"
 
-docker run $runtime -e opts="$opts" \
+docker run $gpus -e opts="$opts" \
     -v $DATA_DIR:$DATA_DIR -v $MODEL_DIR:$MODEL_DIR -v `pwd`:/mlperf \
     -v $OUTPUT_DIR:/output -v /proc:/host_proc \
     -t $image:latest /mlperf/run_helper.sh 2>&1 | tee $OUTPUT_DIR/output.txt


### PR DESCRIPTION
Fix #1274 and fix #1275 
For docker versions greater than `19.03` the flag `--gpus` can be used, as mentioned [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html)