### PR TITLE
Separate QDL class for LON

### DIFF
--- a/loadgen/README.md
+++ b/loadgen/README.md
@@ -128,7 +128,7 @@ QDL implements the protocol to transmit queries over the network and receive res
 The MLperf over the Network will run in Server mode and Offline mode. All LoadGen modes are expected to work as is with insignificant changes. These include running the test in performance mode, accuracy mode, find peak performance mode and compliance mode. The same applies for power measurements.
 
 ### QDL details
-The Query Dispatch Library is implemented by the submitter and interfaces with LoadGen using the same SUT API. All MLPerf Inference SUTs implement the `mlperf::SystemUnderTest` class which is defined in system_under_test.h. The QDL implements `mlperf::QueryDispatchLibrary` class which inherits the `mlperf::SystemUnderTest` class and have the same API and support all existing `mlperf::SystemUnderTest` methods. It has a separate header file query_dispatch_library.h. Using sut with `mlperf::SystemUnderTest` class in LoadGen StartTest is natively upcasting `mlperf::QueryDispatchLibrary` class.
+The Query Dispatch Library is implemented by the submitter and interfaces with LoadGen using the same SUT API. All MLPerf Inference SUTs implement the `mlperf::SystemUnderTest` class which is defined in system_under_test.h. The QDL implements `mlperf::QueryDispatchLibrary` class which inherits the `mlperf::SystemUnderTest` class and has the same API and support all existing `mlperf::SystemUnderTest` methods. It has a separate header file query_dispatch_library.h. Using sut with `mlperf::SystemUnderTest` class in LoadGen StartTest is natively upcasting `mlperf::QueryDispatchLibrary` class.
 
 #### QDL Query issue and response over the network
 
@@ -162,4 +162,4 @@ The `Name` function returns a known string for over the Network SUTs to identify
 ```CPP
 void FlushQueries();
 ```
-It is not specified here how the QDL would query and configure the SUT to execute the above methods. The QDL provides the response to the loadgen after the SUT is ready.
+It is not specified here how the QDL would query and configure the SUT to execute the above methods. The QDL responds to the LoadGen after receiving its own response from the SUT.

--- a/loadgen/README.md
+++ b/loadgen/README.md
@@ -128,7 +128,7 @@ QDL implements the protocol to transmit queries over the network and receive res
 The MLperf over the Network will run in Server mode and Offline mode. All LoadGen modes are expected to work as is with insignificant changes. These include running the test in performance mode, accuracy mode, find peak performance mode and compliance mode. The same applies for power measurements.
 
 ### QDL details
-The Query Dispatch Library is implemented by the submitter and interfaces with LoadGen using the same SUT API. All MLPerf Inference SUTs implement the `mlperf::SystemUnderTest` class which is defined in system_under_test.h. The QDL follows the same API, support all existing `mlperf::SystemUnderTest` methods and use the same header file.
+The Query Dispatch Library is implemented by the submitter and interfaces with LoadGen using the same SUT API. All MLPerf Inference SUTs implement the `mlperf::SystemUnderTest` class which is defined in system_under_test.h. The QDL implements `mlperf::QueryDispatchLibrary` class which inherits the `mlperf::SystemUnderTest` class and have the same API and support all existing `mlperf::SystemUnderTest` methods. It has a separate header file query_dispatch_library.h. Using sut with `mlperf::SystemUnderTest` class in LoadGen StartTest is natively upcasting `mlperf::QueryDispatchLibrary` class.
 
 #### QDL Query issue and response over the network
 

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -69,8 +69,6 @@ void QuerySamplesComplete(QuerySampleResponse* responses, size_t response_count,
 /// \brief Starts the test against SUT with the specified settings.
 /// \details This is the C++ entry point. See mlperf::c::StartTest for the
 /// C entry point.
-/// When working in LON mode the QueryDispatchLibrary class is used and 
-/// natively Upcasted to the sut entry.
 ///
 void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -69,6 +69,8 @@ void QuerySamplesComplete(QuerySampleResponse* responses, size_t response_count,
 /// \brief Starts the test against SUT with the specified settings.
 /// \details This is the C++ entry point. See mlperf::c::StartTest for the
 /// C entry point.
+/// When working in LON mode the QueryDispatchLibrary class is used and 
+/// natively Upcasted to the sut entry.
 ///
 void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,

--- a/loadgen/query_dispatch_library.h
+++ b/loadgen/query_dispatch_library.h
@@ -1,0 +1,44 @@
+/* Copyright 2019 The MLPerf Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/// \file
+/// \brief Defines the QueryDispatchLibrary interface.
+
+#ifndef MLPERF_LOADGEN_QUERY_DISPATCH_LIBRARY_H
+#define MLPERF_LOADGEN_QUERY_DISPATCH_LIBRARY_H
+
+#include <string>
+
+#include "system_under_test.h"
+
+namespace mlperf {
+
+/// \addtogroup LoadgenAPI
+/// @{
+
+/// \brief The interface a client implements for the loadgen over the network to test. The API inherits the System_under_test.h API
+
+class QueryDispatchLibrary : public SystemUnderTest {
+ public:
+  virtual ~QueryDispatchLibrary() {}
+
+  /// \brief A human-readable string for logging purposes. 
+  ///        localName should return from LON node name.
+  virtual const std::string& LocalName() = 0;
+
+};
+
+/// @}
+
+}  // namespace mlperf
+
+#endif  // MLPERF_LOADGEN_QUERY_DISPATCH_LIBRARY_H

--- a/loadgen/query_dispatch_library.h
+++ b/loadgen/query_dispatch_library.h
@@ -25,14 +25,15 @@ namespace mlperf {
 /// \addtogroup LoadgenAPI
 /// @{
 
-/// \brief The interface a client implements for the loadgen over the network to test. The API inherits the System_under_test.h API
+/// \brief The interface a client implements for the LoadGen over the network to test. The API inherits the System_under_test.h API
+/// When working in LON mode the QueryDispatchLibrary class is used and natively Upcasted to the QueryDispatchLibrary class.
 
 class QueryDispatchLibrary : public SystemUnderTest {
  public:
-  virtual ~QueryDispatchLibrary() {}
+  virtual ~QueryDispatchLibrary() = default;
 
   /// \brief A human-readable string for logging purposes. 
-  ///        localName should return from LON node name.
+  ///        localName should return from LON node name. It is not used for now.
   virtual const std::string& LocalName() = 0;
 
 };


### PR DESCRIPTION
PR to handle separation of QDL class from SUT class. Currently with the same functionality of SUT but over the network. Changes to use this code should be done in the LON demo.
If we add specific functionality for the QDL it might best to have a new entry point of StartTestLon that will include this functionality (there is a preparation for a local LON node name) .
Update the readme accordingly.