### PR TITLE
Added option to use Preprocessed Dataset for Vision Benchmarks

### DIFF
--- a/vision/classification_and_detection/python/coco.py
+++ b/vision/classification_and_detection/python/coco.py
@@ -21,7 +21,7 @@ log = logging.getLogger("coco")
 
 class Coco(dataset.Dataset):
     def __init__(self, data_path, image_list, name, use_cache=0, image_size=None,
-                 image_format="NHWC", pre_process=None, count=None, cache_dir=None,use_label_map=False):
+                 image_format="NHWC", pre_process=None, count=None, cache_dir=None, preprocessed_dir=None, use_label_map=False, threads=os.cpu_count()):
         super().__init__()
         self.image_size = image_size
         self.image_list = []

--- a/vision/classification_and_detection/python/imagenet.py
+++ b/vision/classification_and_detection/python/imagenet.py
@@ -21,7 +21,7 @@ log = logging.getLogger("imagenet")
 class Imagenet(dataset.Dataset):
 
     def __init__(self, data_path, image_list, name, use_cache=0, image_size=None,
-            image_format="NHWC", pre_process=None, count=None, cache_dir=None, threads=os.cpu_count()):
+            image_format="NHWC", pre_process=None, count=None, cache_dir=None, preprocessed_dir=None, threads=os.cpu_count()):
         super(Imagenet, self).__init__()
         if image_size is None:
             self.image_size = [224, 224, 3]
@@ -32,10 +32,16 @@ class Imagenet(dataset.Dataset):
         self.image_list = []
         self.label_list = []
         self.count = count
-        self.use_cache = use_cache
-        self.cache_dir = os.path.join(cache_dir, "preprocessed", name, image_format)
         self.data_path = data_path
-        self.pre_process = pre_process
+        self.pre_process = pre_process # if None we assume data_path is having preprocessed dataset
+        self.use_cache = use_cache
+        if pre_process:
+            if preprocessed_dir:
+                self.cache_dir = preprocessed_dir
+            else:
+                self.cache_dir = os.path.join(cache_dir, "preprocessed", name, image_format)
+        else:
+            self.cache_dir = cache_dir
         # input images are in HWC
         self.need_transpose = True if image_format == "NCHW" else False
 
@@ -43,12 +49,6 @@ class Imagenet(dataset.Dataset):
         if image_list is None:
             # by default look for val_map.txt
             image_list = os.path.join(data_path, "val_map.txt")
-
-        os.makedirs(self.cache_dir, exist_ok=True)
-
-        start = time.time()
-        N = threads
-        import concurrent.futures
         with open(image_list, 'r') as fp:
             for count, line in enumerate(fp):
                 pass
@@ -57,9 +57,19 @@ class Imagenet(dataset.Dataset):
             CNT = count
         else:
             CNT = count if count <= self.count else self.count
+
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+        start = time.time()
+        N = threads
+        import concurrent.futures
         if N > CNT:
             N = CNT
-        log.info("Preprocessing {} images using {} threads".format(CNT, N))
+
+        if not pre_process:
+            log.info("Loading {} preprocessed images using {} threads".format(CNT, N))
+        else:
+            log.info("Preprocessing {} images using {} threads".format(CNT, N))
 
         with open(image_list, 'r') as f:
             lists = []
@@ -87,26 +97,31 @@ class Imagenet(dataset.Dataset):
         if self.not_found > 0:
             log.info("reduced image list, %d images not found", self.not_found)
 
-        log.info("loaded {} images, cache={}, took={:.1f}sec".format(
-            len(self.image_list), use_cache, time_taken))
+        log.info("loaded {} images, cache={}, already_preprocessed={}, took={:.1f}sec".format(
+            len(self.image_list), use_cache, pre_process is None, time_taken))
         self.label_list = np.array(self.label_list)
 
     def process(self, data_path, files, image_list, label_list):
         for s in files:
             image_name, label = re.split(r"\s+", s.strip())
             src = os.path.join(data_path, image_name)
-            if not os.path.exists(src):
-                # if the image does not exists ignore it
-                self.not_found += 1
-                continue
-            os.makedirs(os.path.dirname(os.path.join(self.cache_dir, image_name)), exist_ok=True)
-            dst = os.path.join(self.cache_dir, image_name)
-            if not os.path.exists(dst + ".npy"):
-                # cache a preprocessed version of the image
-                # TODO: make this multi threaded ?
-                img_org = cv2.imread(src)
-                processed = self.pre_process(img_org, need_transpose=self.need_transpose, dims=self.image_size)
-                np.save(dst, processed)
+            if not self.pre_process:
+                if not os.path.exists(os.path.join(data_path, image_name) + ".npy"):
+                    # if the image does not exists ignore it
+                    self.not_found += 1
+                    continue
+            else:
+                if not os.path.exists(src):
+                    # if the image does not exists ignore it
+                    self.not_found += 1
+                    continue
+                os.makedirs(os.path.dirname(os.path.join(self.cache_dir, image_name)), exist_ok=True)
+                dst = os.path.join(self.cache_dir, image_name)
+                if not os.path.exists(dst + ".npy"):
+                    # cache a preprocessed version of the image
+                    img_org = cv2.imread(src)
+                    processed = self.pre_process(img_org, need_transpose=self.need_transpose, dims=self.image_size)
+                    np.save(dst, processed)
             image_list.append(image_name)
             label_list.append(int(label))
 

--- a/vision/classification_and_detection/python/main.py
+++ b/vision/classification_and_detection/python/main.py
@@ -230,6 +230,8 @@ def get_args():
     parser.add_argument("--qps", type=int, help="target qps")
     parser.add_argument("--cache", type=int, default=0, help="use cache")
     parser.add_argument("--cache_dir", type=str, default=None, help="dir path for caching")
+    parser.add_argument("--preprocessed_dir", type=str, default=None, help="dir path for storing preprocessed images (overrides cache_dir)")
+    parser.add_argument("--use_preprocessed_dataset", action="store_true", help="use preprocessed dataset instead of the original")
     parser.add_argument("--accuracy", action="store_true", help="enable accuracy pass")
     parser.add_argument("--find-peak-performance", action="store_true", help="enable finding peak performance pass")
     parser.add_argument("--debug", action="store_true", help="debug, turn traces on")
@@ -475,6 +477,8 @@ def main():
 
     # dataset to use
     wanted_dataset, pre_proc, post_proc, kwargs = SUPPORTED_DATASETS[args.dataset]
+    if args.use_preprocessed_dataset:
+        pre_proc=None
     ds = wanted_dataset(data_path=args.dataset_path,
                         image_list=args.dataset_list,
                         name=args.dataset,
@@ -483,6 +487,7 @@ def main():
                         use_cache=args.cache,
                         count=count,
                         cache_dir=args.cache_dir,
+                        preprocessed_dir=args.preprocessed_dir,
                         threads=args.threads,
                         **kwargs)
     # load model to backend


### PR DESCRIPTION
This PR can enable the vision benchmarks to run without the original dataset if preprocessed dataset path is given.