### PR TITLE
Fix test 05

### DIFF
--- a/compliance/nvidia/TEST05/README.md
+++ b/compliance/nvidia/TEST05/README.md
@@ -17,7 +17,11 @@ Performance must be within 5% of the submission performance. In single stream mo
 ## Instructions
 
 ### Part I
-Run the benchmark with the provided audit.config in the corresponding benchmark subdirectory. Note that audit.config must be copied to the directory where the benchmark is being run from. Verification that audit.config was properly read can be done by checking that loadgen has found audit.config in mlperf_log_detail.txt 
+Run the benchmark with the provided audit.config in the corresponding benchmark subdirectory. 
+
+The audit.config file must be copied to the directory where the benchmark is being run from. Verification that audit.config was properly read can be done by checking that loadgen has found audit.config in mlperf_log_detail.txt 
+
+Alternatively, you can alter the mlperf.conf (or the configuration file's copy your benchmark is using) by setting the value `*.*.test05 = 1`. For this option make sure you have the right values for `*.*.test05_qsl_rng_seed`, `*.*.test05_sample_index_rng_seed` and `*.*.test05_schedule_rng_seed` included in your configuration file.
 
 ### Part II
 Run the verification script:

--- a/loadgen/bindings/python_api.cc
+++ b/loadgen/bindings/python_api.cc
@@ -322,6 +322,12 @@ PYBIND11_MODULE(mlperf_loadgen, m) {
                      &TestSettings::performance_issue_same_index)
       .def_readwrite("performance_sample_count_override",
                      &TestSettings::performance_sample_count_override)
+      .def_readwrite("test05",
+                     &TestSettings::test05)
+      .def_readwrite("test05_qsl_rng_seed", &TestSettings::qsl_rng_seed)
+      .def_readwrite("test05_sample_index_rng_seed",
+                     &TestSettings::sample_index_rng_seed)
+      .def_readwrite("test05_schedule_rng_seed", &TestSettings::schedule_rng_seed)
       .def("FromConfig", &TestSettings::FromConfig, "FromConfig.");
 
   pybind11::enum_<LoggingMode>(m, "LoggingMode")

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -1161,6 +1161,23 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
     const std::string generic_model = "*";
     test_settings.FromConfig(audit_config_filename, generic_model,
                              audit_scenario);
+  }else if(test_settings.test05){
+    // If the configuration indicates we are running test05,
+    // random seeds
+    LogDetail([](AsyncDetail& detail) {
+#if USE_NEW_LOGGING_FORMAT
+      MLPERF_LOG_WARNING(detail, "warning_generic_message",
+                         "Test05 flag detected"
+                         " Overriding random seeds");
+#else
+      detail(
+          "Test05 flag detected"
+          " Overriding random seeds");
+#endif
+    });
+    test_settings.qsl_rng_seed = requested_settings.test05_qsl_rng_seed;
+    test_settings.sample_index_rng_seed = requested_settings.test05_sample_index_rng_seed;
+    test_settings.schedule_rng_seed = requested_settings.test05_schedule_rng_seed;
   }
 
   loadgen::TestSettingsInternal sanitized_settings(

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -227,6 +227,13 @@ struct TestSettings {
   /// accuracy log in performance mode for compliance testing
   uint64_t accuracy_log_sampling_target = 0;
 
+  /// \brief Variables for running test05 from native config. A boolean that
+  /// determines whether or not to run test05 and three random seed to run the test
+  bool test05 = false;
+  uint64_t test05_qsl_rng_seed = 0;
+  uint64_t test05_sample_index_rng_seed = 0;
+  uint64_t test05_schedule_rng_seed = 0;
+
   /// \brief Load mlperf parameter config from file.
   int FromConfig(const std::string &path, const std::string &model,
                  const std::string &scenario);

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -48,7 +48,7 @@ TestSettingsInternal::TestSettingsInternal(
       performance_issue_same(requested.performance_issue_same),
       performance_issue_same_index(requested.performance_issue_same_index),
       performance_sample_count(0),
-      sample_concatenate_permutation(false) {
+      sample_concatenate_permutation(false){
   // Target QPS, target latency, and max_async_queries.
   switch (requested.scenario) {
     case TestScenario::SingleStream:
@@ -666,6 +666,12 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
            &performance_sample_count_override, nullptr);
   if (lookupkv(model, scenario, "sample_concatenate_permutation", &val, nullptr))
     sample_concatenate_permutation = (val == 1) ? true : false;
+  if (lookupkv(model, scenario, "test05", &val, nullptr))
+    test05 = (val == 1) ? true : false;
+  lookupkv(model, scenario, "test05_qsl_rng_seed", &test05_qsl_rng_seed, nullptr);
+  lookupkv(model, scenario, "test05_sample_index_rng_seed", &test05_sample_index_rng_seed,
+           nullptr);
+  lookupkv(model, scenario, "test05_schedule_rng_seed", &test05_schedule_rng_seed, nullptr);
 
   // keys that apply to SingleStream
   lookupkv(model, "SingleStream", "target_latency_percentile", nullptr,

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -21,6 +21,11 @@ rnnt.*.performance_sample_count_override = 2513
 *.*.sample_index_rng_seed = 4163916728725999944
 # 0x04267cf482328355
 *.*.schedule_rng_seed = 299063814864929621
+# Set seeds for TEST_05. The seeds will be distributed two weeks before the submission.
+*.*.test05_qsl_rng_seed = 313588358309856706
+*.*.test05_sample_index_rng_seed = 471397156132239067
+*.*.test05_schedule_rng_seed = 413914573387865862
+*.*.test05 = 0
 
 
 *.SingleStream.target_latency_percentile = 90


### PR DESCRIPTION
Fix #1244 
- Add TEST05 seeds to `mlperf.conf` and `TestSettings`
- Add flag to run `test05` to `mlperf.conf` and `TestSettings`
- Add documentation about how to run `test05` using the `mlperf.conf`