### PR TITLE
Infer system file inside measurements directory

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -2449,6 +2449,15 @@ def check_measurement_dir(measurement_dir, fname, system_desc, root, model,
       system_file = i
       end = len(".json")
       break
+
+  if not system_file and os.environ.get("INFER_SYSTEM_FILE","") == "yes":
+    for i in files:
+      if i.endswith(".json"):
+        system_file = system_desc+".json"
+        os.rename(os.path.join(measurement_dir, i), os.path.join(measurement_dir, system_file))
+        end = len(".json")
+        break
+
   if system_file:
     with open(os.path.join(measurement_dir, system_file), "r") as f:
       j = json.load(f)


### PR DESCRIPTION
This change can help in easy renaming of the SUTs as it'll automatically rename the system_desc.json files inside the measurements directory. The change is safe as it'll happen only when the env variable `INFER_SYSTEM_FILE` equals `yes`.