### PR TITLE
Updated URL of power-dev to use absolute URL 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/MIC-DKFZ/nnUNet.git
 [submodule "tools/submission/power-dev"]
 	path = tools/submission/power-dev
-	url = ../power-dev
+	url = https://github.com/mlcommons/power-dev


### PR DESCRIPTION
power-dev submodule was specified as a relative path. That didn't work when I just forked the inference repo and only the inference repo. Updated it to absolute path so it can work anywhere.