### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "vision/medical_imaging/3d-unet-brats19/nnUnet"]
 	path = vision/medical_imaging/3d-unet-brats19/nnUnet
 	url = https://github.com/MIC-DKFZ/nnUNet.git
-[submodule "tools/submission/power-dev"]
-	path = tools/submission/power-dev
-	url = ../power-dev


### PR DESCRIPTION
Removed the submodule mlcommons/power-dev as the power-checker is now copied into the inference repository. Those doing inference power submission needs to checkout power-dev separately.