### PR TITLE
GPT-J Reference Implementation - Fix minor issues

### DIFF
--- a/language/gpt-j/README.md
+++ b/language/gpt-j/README.md
@@ -43,8 +43,7 @@ cd ../..
 ### Clone 
 ```sh
 git clone https://github.com/mlcommons/inference.git
-cd inference/
-git checkout master
+cd inferenc
 cd language/gpt-j/
 ```
 

--- a/language/gpt-j/README.md
+++ b/language/gpt-j/README.md
@@ -43,7 +43,7 @@ cd ../..
 ### Clone 
 ```sh
 git clone https://github.com/mlcommons/inference.git
-cd inferenc
+cd inference
 cd language/gpt-j/
 ```
 

--- a/language/gpt-j/README.md
+++ b/language/gpt-j/README.md
@@ -42,9 +42,9 @@ cd ../..
 ```
 ### Clone 
 ```sh
-git clone https://github.com/badhri-intel/inference.git
+git clone https://github.com/mlcommons/inference.git
 cd inference/
-git checkout gpt-j/ref_implementation
+git checkout master
 cd language/gpt-j/
 ```
 
@@ -61,10 +61,8 @@ pip install datasets
 python prepare-calibration.py --calibration-list-file calibration-list.txt --output-dir </path/to/output-folder>
 ```
 ### Download GPT-J model
-Downloads the model and saves it in model/ directory. If you have access to fine-tuned model, you can use that instead by naming the directory as model/.
-```
-python download_gptj.py
-```
+Please download the internal fine-tuned GPT-J checkpoint and rename it as model/. The download_gptj.py only downloads the default huggingface model which is not fine-tuned on CNN-Daily mail dataset.
+
 ### Running the Benchmark
 Replace the model and dataset path arguments with your corresponding paths. For evaluating the ROUGE score after the run, include --accuracy as shown below. For user specific target qps, please include user.conf.
 ```
@@ -75,6 +73,14 @@ Evaluates the ROGUE scores from the accuracy logs. Only applicable when specifiy
 ```
 python evaluation.py --mlperf-accuracy-file ./build/logs/mlperf_log_accuracy.json --dataset-file ./data/cnn_eval.json
 ```
+
+### Reference Model - ROUGE scores
+The following are the rouge scores obtained when evaluating the fp32 model on the entire test set using greedy search (11490 samples)
+
+ROUGE 1 - 42.39
+ROUGE 2 - 18.45
+ROUGE L - 28.62
+
 ### License:
 Apache License Version 2.0.
 

--- a/language/gpt-j/README.md
+++ b/language/gpt-j/README.md
@@ -74,13 +74,13 @@ python evaluation.py --mlperf-accuracy-file ./build/logs/mlperf_log_accuracy.jso
 ```
 
 ### Reference Model - ROUGE scores
-The following are the rouge scores obtained when evaluating the fp32 model on the entire test set using greedy search (11490 samples)
+The following are the rouge scores obtained when evaluating the GPT-J fp32 model on the entire validation set (using greedy search)
 
-ROUGE 1 - 42.39  
+ROUGE 1 - 41.5945  
 
-ROUGE 2 - 18.45  
+ROUGE 2 - 18.4929  
 
-ROUGE L - 28.62  
+ROUGE L - 28.3975  
 
 ### License:
 Apache License Version 2.0.

--- a/language/gpt-j/README.md
+++ b/language/gpt-j/README.md
@@ -77,9 +77,11 @@ python evaluation.py --mlperf-accuracy-file ./build/logs/mlperf_log_accuracy.jso
 ### Reference Model - ROUGE scores
 The following are the rouge scores obtained when evaluating the fp32 model on the entire test set using greedy search (11490 samples)
 
-ROUGE 1 - 42.39
-ROUGE 2 - 18.45
-ROUGE L - 28.62
+ROUGE 1 - 42.39  
+
+ROUGE 2 - 18.45  
+
+ROUGE L - 28.62  
 
 ### License:
 Apache License Version 2.0.

--- a/language/gpt-j/download_cnndm.py
+++ b/language/gpt-j/download_cnndm.py
@@ -35,22 +35,6 @@ prompt_length = len(tokenizer(instruction_template)["input_ids"])
 max_sample_length = tokenizer.model_max_length - prompt_length
 
 
-# The maximum total input sequence length after tokenization.
-# Sequences longer than this will be truncated, sequences shorter will be padded.
-tokenized_inputs = concatenate_datasets([dataset["train"], dataset["validation"]]).map(lambda x: tokenizer(x[text_column], truncation=True), batched=True, remove_columns=[text_column, summary_column])
-max_source_length = max([len(x) for x in tokenized_inputs["input_ids"]])
-max_source_length = min(max_source_length, max_sample_length)
-
-
-# The maximum total sequence length for target text after tokenization.
-# Sequences longer than this will be truncated, sequences shorter will be padded."
-tokenized_targets = concatenate_datasets([dataset["train"], dataset["validation"]]).map(lambda x: tokenizer(x[summary_column], truncation=True), batched=True, remove_columns=[text_column, summary_column])
-target_lenghts = [len(x) for x in tokenized_targets["input_ids"]]
-# use 95th percentile as max target length
-max_target_length = int(np.percentile(target_lenghts, 95))
-
-
-
 def preprocess_function(sample, padding="max_length"):
     # create list of samples
     inputs = []

--- a/language/gpt-j/evaluation.py
+++ b/language/gpt-j/evaluation.py
@@ -35,7 +35,7 @@ def postprocess_text(preds, targets):
 
 
 def main():
-
+    np.random.seed(0)
     args = get_args()
     model_name = "EleutherAI/gpt-j-6B"
     dataset_path = args.dataset_file

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -30,7 +30,7 @@ def get_args():
         "--mlperf_conf", default="mlperf.conf", help="mlperf rules config")
     parser.add_argument("--user_conf", default="user.conf",
                         help="user config for user LoadGen settings such as target QPS")
-    parser.add_argument("--max_examples", type=int, default=4869,
+    parser.add_argument("--max_examples", type=int, default=13368,
                         help="Maximum number of examples to consider (not limited by default)")
     args = parser.parse_args()
     return args

--- a/language/gpt-j/user.conf
+++ b/language/gpt-j/user.conf
@@ -1,0 +1,4 @@
+# The format of this config file is 'key = value'.
+# The key has the format 'model.scenario.key'. Value is mostly int64_t.
+# Model maybe '*' as wildcard. In that case the value applies to all models.
+# All times are in milli seconds


### PR DESCRIPTION
Following issues are fixed in this PR :

1. Update README - Added reference model ROUGE scores, updated repo name and removed default gpt-j model download instruction to avoid confusion.
2. Removed redundant code in download_cnndm.py
3. Fixed ROUGE score variation in evaluation.py by adding numpy random seed
4. Updated max_examples in main.py to total length of eval dataset
5. Added empty user.conf to avoid warnings