### PR TITLE
Remove randomness in ROUGE score computation & update decoding to beam search

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -14,7 +14,7 @@ gen_kwargs = {
     "early_stopping": True,
     "max_new_tokens": 128,
     "min_new_tokens": 30,
-    "num_beams": 1,
+    "num_beams": 4,
 }
 
 

--- a/language/gpt-j/evaluation.py
+++ b/language/gpt-j/evaluation.py
@@ -35,7 +35,7 @@ def postprocess_text(preds, targets):
 
 
 def main():
-    np.random.seed(0)
+
     args = get_args()
     model_name = "EleutherAI/gpt-j-6B"
     dataset_path = args.dataset_file
@@ -75,8 +75,8 @@ def main():
     preds, targets = postprocess_text(preds_decoded_text, target_required)
 
 
-    result = metric.compute(predictions=preds, references=targets, use_stemmer=True)
-    result = {k: round(v * 100, 4) for k, v in result.items()}
+    result = metric.compute(predictions=preds, references=targets, use_stemmer=True,use_aggregator=False)
+    result = {k: round(np.mean(v) * 100, 4) for k, v in result.items()}
     prediction_lens = [len(pred) for pred in preds]
     result["gen_len"] = np.sum(prediction_lens)
     result["gen_num"] = len(preds)


### PR DESCRIPTION
Permanent fix to remove randomness in ROUGE score computation. 
By default, use_aggregator is set to True and that triggers a random sampling as mentioned in this [issue](https://github.com/huggingface/evaluate/issues/186) which causes minor variation in ROUGE scores across runs. 