### PR TITLE
Remove min_query_count for SS, MS and Server scenarios

### DIFF
--- a/mlperf.conf
+++ b/mlperf.conf
@@ -32,12 +32,12 @@ rnnt.*.performance_sample_count_override = 2513
 
 *.SingleStream.target_latency_percentile = 90
 *.SingleStream.min_duration = 600000
-*.SingleStream.min_query_count = 1024
+#*.SingleStream.min_query_count = 1024
 
 *.MultiStream.target_latency_percentile = 99
 *.MultiStream.samples_per_query = 8
 *.MultiStream.min_duration = 600000
-*.MultiStream.min_query_count = 270336
+#*.MultiStream.min_query_count = 270336
 retinanet.MultiStream.target_latency = 528
 
 # 3D-UNet uses equal issue mode
@@ -47,7 +47,7 @@ retinanet.MultiStream.target_latency = 528
 *.Server.target_latency_percentile = 99
 *.Server.target_duration = 0
 *.Server.min_duration = 600000
-*.Server.min_query_count = 270336
+#*.Server.min_query_count = 270336
 resnet50.Server.target_latency = 15
 retinanet.Server.target_latency = 100
 bert.Server.target_latency = 130


### PR DESCRIPTION
With early stopping being there we don't need min_query_count in mlperf.conf