### PR TITLE
fix: decoding of non-ascii captured output of a git command

### DIFF
--- a/loadgen/version_generator.py
+++ b/loadgen/version_generator.py
@@ -22,6 +22,7 @@ import errno
 import hashlib
 import os
 import sys
+import subprocess
 
 
 # Creates a C++ raw string literal using a delimiter that is very
@@ -43,8 +44,8 @@ def generate_loadgen_version_definitions_git(ofile, git_command):
     git_rev = os.popen(git_command + "rev-parse --short=10 HEAD").read()
     git_commit_date = os.popen(git_command + "log --format=\"%cI\" -n 1").read()
     git_status = os.popen(git_command + "status -s -uno").read()
-    git_log = os.popen(
-        git_command + "log --pretty=oneline -n 16 --no-decorate").read()
+    git_log = subprocess.Popen(
+        git_command + "log --pretty=oneline -n 16 --no-decorate", stdout=subprocess.PIPE, shell=True, encoding='ascii', errors="ignore" ).stdout.read()
     ofile.write(func_def("GitRevision", "\"" + git_rev[0:-1] + "\""))
     ofile.write(func_def("GitCommitDate", "\"" + git_commit_date[0:-1] + "\""))
     ofile.write(func_def("GitStatus", make_raw_string(git_status[0:-1])))


### PR DESCRIPTION
Recently (?) introduced mlcommons-bot starts its' commit messages with a Unicode character that crashes os.popen().read() on some Pythons.

The problem with os.popen() is that is an old and inflexible way of reading command output. You cannot set the expected encoding, or a desired reaction to an error.

For a long time subprocess.Popen() has been a suggested substitute.
