### PR TITLE
Fix GPT-J accuracy pattern

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -1166,10 +1166,10 @@ ACC_PATTERN = {
     "F1": r"^{[\"\']exact_match[\"\']\:\s*[\d\.]+,\s*[\"\']f1[\"\']\:\s*([\d\.]+)}",
     "WER": r"Word Error Rate\:.*, accuracy=([0-9\.]+)%",
     "DICE": r"Accuracy\:\s*mean\s*=\s*([\d\.]+).*",
-    "ROUGE1": r"^ROUGE1=([\d\.]+).*",
-    "ROUGE2": r"^ROUGE2=([\d\.]+).*",
-    "ROUGEL": r"^ROUGEL=([\d\.]+).*",
-    "GEN_LEN": r"^GEN_LEN=([\d\.]+).*",
+    "ROUGE1": r"'rouge1':\s([\d.]+).*",
+    "ROUGE2": r"'rouge2':\s([\d.]+).*",
+    "ROUGEL": r"'rougeLsum':\s([\d.]+).*",
+    "GEN_LEN": r"'gen_len':\s([\d.]+).*",
 }
 
 SYSTEM_DESC_REQUIRED_FIELDS = [

--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -1166,10 +1166,10 @@ ACC_PATTERN = {
     "F1": r"^{[\"\']exact_match[\"\']\:\s*[\d\.]+,\s*[\"\']f1[\"\']\:\s*([\d\.]+)}",
     "WER": r"Word Error Rate\:.*, accuracy=([0-9\.]+)%",
     "DICE": r"Accuracy\:\s*mean\s*=\s*([\d\.]+).*",
-    "ROUGE1": r"'rouge1':\s([\d.]+).*",
-    "ROUGE2": r"'rouge2':\s([\d.]+).*",
-    "ROUGEL": r"'rougeLsum':\s([\d.]+).*",
-    "GEN_LEN": r"'gen_len':\s([\d.]+).*",
+    "ROUGE1": r".*'rouge1':\s([\d.]+).*",
+    "ROUGE2": r".*'rouge2':\s([\d.]+).*",
+    "ROUGEL": r".*'rougeLsum':\s([\d.]+).*",
+    "GEN_LEN": r".*'gen_len':\s([\d.]+).*",
 }
 
 SYSTEM_DESC_REQUIRED_FIELDS = [


### PR DESCRIPTION
The output of the `evaluation.py` has the following format. The regular expressions need to be updated to match the patterns.
```
Constructing QSL
Encoding Samples

Results

{'rouge1': 42.9757, 'rouge2': 18.9497, 'rougeL': 29.0426, 'rougeLsum': 40.2181, 'gen_len': 4568360, 'gen_num': 13368}
Finished destroying QSL.
```
