### PR TITLE
Fix submission_checker for GPT-J benchmark

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -1166,9 +1166,9 @@ ACC_PATTERN = {
     "F1": r"^{[\"\']exact_match[\"\']\:\s*[\d\.]+,\s*[\"\']f1[\"\']\:\s*([\d\.]+)}",
     "WER": r"Word Error Rate\:.*, accuracy=([0-9\.]+)%",
     "DICE": r"Accuracy\:\s*mean\s*=\s*([\d\.]+).*",
-    "ROUGE1": r"'rouge1':\s([\d.]+).*",
+    "ROUGE1": r".*'rouge1':\s([\d.]+).*",
     "ROUGE2": r".*'rouge2':\s([\d.]+).*",
-    "ROUGEL": r".*'rougeLsum':\s([\d.]+).*",
+    "ROUGEL": r".*'rougeL':\s([\d.]+).*",
     "GEN_LEN": r".*'gen_len':\s([\d.]+).*",
 }
 
@@ -3129,7 +3129,6 @@ def check_compliance_acc_dir(test_dir, model, config):
                             m = re.match(pattern, line)
                             if m:
                                 acc_baseline[acc_type] = float(m.group(1))
-                                break
                 with open(
                     os.path.join(test_acc_path, "compliance_accuracy.txt"),
                     "r",


### PR DESCRIPTION
We found an issue with parsing accuracy log in the submission checker.

Output from evaluation.py is in the following format:
`{'rouge1': 42.9877, 'rouge2': 20.1472, 'rougeL': 29.968, 'rougeLsum': 40.1381, 'gen_len': 4020129, 'gen_num': 13368}
`

Change description:
- fixed regex for rouge1
- rougeLsum value was parsed as rougeL
- `break` instruction was causing that only rouge1 was read. In GPT-J we have four accuracy metrics.