### PR TITLE
Fix timezone offset issue

### DIFF
--- a/tools/submission/power/power_checker.py
+++ b/tools/submission/power/power_checker.py
@@ -401,9 +401,10 @@ def phases_check(
 
         with open(spl_fname) as f:
             for line in f:
+                timezone_offset = int(server_sd.json_object["timezone"])
                 timestamp = (
                     datetime.strptime(line.split(",")[1], datetime_format)
-                ).timestamp()
+                ).timestamp() + timezone_offset
                 if timestamp > power_begin and timestamp < power_end:
                     cpower = float(line.split(",")[3])
                     cpf = float(line.split(",")[9])


### PR DESCRIPTION
Currently, the avg_power delta check between the ranging and the testing runs works as expected only if the submission checker is run at UTC timezone. Based on my tests this issue is coming only when the power server is run on a Windows machine and the runtime is longer than the timezone delta from GMT. 
