### PR TITLE
GPT-J SingleStream use equal issue mode

### DIFF
--- a/mlperf.conf
+++ b/mlperf.conf
@@ -39,6 +39,9 @@ retinanet.MultiStream.target_latency = 528
 # 3D-UNet uses equal issue mode
 3d-unet.*.sample_concatenate_permutation = 1
 
+# GPT-J uses equal issue mode for Single-Stream
+gptj.SingleStream.sample_concatenate_permutation = 1
+
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99
 *.Server.target_duration = 0


### PR DESCRIPTION
GPT-J has non-uniform inputs in terms of work size. SingleStream suffers from this especially when audit tests are running (TEST01). 3D-UNet solved this with equal-issue mode. 

Adding knob to enable equal-issue mode for GPT-J SingleStream.