### PR TITLE
[Urgent] Fix submission UI: dlrm-v2/GPTJ key mismatch

### DIFF
--- a/tools/submission/generate_final_report.py
+++ b/tools/submission/generate_final_report.py
@@ -134,11 +134,12 @@ def main():
           'rnnt': ['SingleStream', 'Offline'],
           'bert-99': ['SingleStream', 'Offline'],
           'bert-99.9': [],
-          'dlrm-99': [],
-          'dlrm-99.9': [],
+          'dlrm-v2-99': [],
+          'dlrm-v2-99.9': [],
           '3d-unet-99': ['SingleStream', 'Offline'],
           '3d-unet-99.9': ['SingleStream', 'Offline'],
           'gptj-99': ['SingleStream', 'Offline'],
+          'gptj-99.9': ['SingleStream', 'Offline'],
       }
   }
 


### PR DESCRIPTION
The submission UI is reporting errors for keyError:
```
apply_series_generator
    results[i] = self.f(v)
  File "/tmp/inference/tools/submission/generate_final_report.py", line 175, in <lambda>
    lambda y: y['Scenario'] in filter_scenarios[suite][y['Model']], axis=1)
KeyError: 'dlrm-v2-99.9'
```