### PR TITLE
Improve pybind11 integration in setup.py

### DIFF
--- a/loadgen/setup.py
+++ b/loadgen/setup.py
@@ -77,7 +77,7 @@ mlperf_long_description = (this_directory / "README.md").read_text(encoding="utf
 mlperf_loadgen_module = Pybind11Extension(
         "mlperf_loadgen",
         define_macros=[("MAJOR_VERSION", "3"), ("MINOR_VERSION", "1")],
-        include_dirs=[".", "../third_party/pybind/include"],
+        include_dirs=[".", get_include()],
         sources=mlperf_loadgen_sources,
         depends=mlperf_loadgen_headers)
 

--- a/loadgen/setup.py
+++ b/loadgen/setup.py
@@ -28,6 +28,8 @@ from setuptools import Extension
 from setuptools import setup
 from version_generator import generate_loadgen_version_definitions
 from pathlib import Path
+from pybind11 import get_include
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 generated_version_source_filename = "generated/version_generated.cc"
 generate_loadgen_version_definitions(generated_version_source_filename, ".")
@@ -72,7 +74,7 @@ mlperf_loadgen_sources = (mlperf_loadgen_sources_no_gen +
 mlperf_long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 
-mlperf_loadgen_module = Extension(
+mlperf_loadgen_module = Pybind11Extension(
         "mlperf_loadgen",
         define_macros=[("MAJOR_VERSION", "3"), ("MINOR_VERSION", "1")],
         include_dirs=[".", "../third_party/pybind/include"],
@@ -83,6 +85,7 @@ setup(name="mlperf_loadgen",
       version="3.1",
       description="MLPerf Inference LoadGen python bindings",
       url="https://mlcommons.org/",
+      cmdclass={"build_ext": build_ext},
       ext_modules=[mlperf_loadgen_module],
       long_description=mlperf_long_description,
       long_description_content_type='text/markdown')


### PR DESCRIPTION
* Use Pybind11Extension to add necessary flags. This fixes build on macOS
* Use build_ext to use highest supported C++ level
* Use pybind11.get_include() instead of searching for submodule path. This effectively eliminates the needs of pybind11 submodule and fixes #1490 in a future-proof way
