### PR TITLE
Bugfix and enhancement for ray-BERT SUT

### DIFF
--- a/language/bert/ray_SUT.py
+++ b/language/bert/ray_SUT.py
@@ -71,7 +71,7 @@ class TorchPredictor:
                 torch_tensorrt.Input(shape=[batch_size, 384], dtype=torch.int32),
                 torch_tensorrt.Input(shape=[batch_size, 384], dtype=torch.int32),
         ],
-        enabled_precisions= {torch.float32},
+        enabled_precisions= {torch.float32, torch.float16},
         workspace_size=2000000000,
         truncate_long_and_double=True)
 

--- a/language/bert/ray_SUT.py
+++ b/language/bert/ray_SUT.py
@@ -154,23 +154,15 @@ class BERT_Ray_SUT():
         # print("samples len", len(batch_samples))
         batch_inference_results = list(self.pool.map_unordered(lambda a, v: a.forward.remote(v), batch_samples))
 
-        results = []
+        cur_query_index = 0
         for batch_inference_result in batch_inference_results:
             batch_inference_result = batch_inference_result["output"]
             for inference_result in batch_inference_result:
                 response_array = array.array("B", inference_result.tobytes())
                 bi = response_array.buffer_info()
-                results.append(bi)
-        
-        # print("results len", len(results))
-        
-        responses = []
-        for i in range(len(query_samples)):
-            # print(query_samples[i].index)
-            bi = results[i]
-            response = lg.QuerySampleResponse(query_samples[i].id, bi[0], bi[1])
-            responses.append(response)
-        lg.QuerySamplesComplete(responses)
+                response = lg.QuerySampleResponse(query_samples[cur_query_index].id, bi[0], bi[1])
+                lg.QuerySamplesComplete([response])
+                cur_query_index += 1
 
     def flush_queries(self):
         pass


### PR DESCRIPTION
In this PR I performed some bugfixes and enhancements to language/bert/ray_SUT.py, including:

- Fix the bug that CM's "accuracy" test yield low accuracy value
- Enable FP16 inference (another 3x speedup on 4090!)
- Show a warning when no existing RAY cluster is detected

NOTE. In another PR, https://github.com/mlcommons/ck/pull/1037, I add support for launching this SUT from the cmind framework.