### PR TITLE
Modifying the min queries constraint for the Offline scenario

### DIFF
--- a/mlperf.conf
+++ b/mlperf.conf
@@ -57,10 +57,19 @@ gptj.Server.target_latency = 20000
 
 *.Offline.target_latency_percentile = 90
 *.Offline.min_duration = 600000
+
 # In Offline scenario, we always have one query. But LoadGen maps this to
-# min_sample_count internally in Offline scenario, so set this to 24576 since
-# the rule requires that Offline scenario run for at least 24576 samples.
-*.Offline.min_query_count = 24576
+# min_sample_count internally in Offline scenario. If the dataset size is larger 
+# than 24576 we limit the min_query_count to 24576 and otherwise we use 
+# the dataset size as the limit
+
+resnet50.Offline.min_query_count = 24576
+retinanet.Offline.min_query_count = 24576
+dlrm-v2.Offline.min_query_count = 24576
+bert.Offline.min_query_count = 10833
+gptj.Offline.min_query_count = 13368
+rnnt.Offline.min_query_count = 2513
+3d-unet.Offline.min_query_count = 43
 
 # These fields should be defined and overridden by user.conf.
 *.SingleStream.target_latency = 10


### PR DESCRIPTION
Modifying the min queries constraint for the Offline scenario. PR for the corresponding rule change is given at

https://github.com/mlcommons/inference_policies/pull/286