### PR TITLE
Add compliance TEST06

### DIFF
--- a/compliance/nvidia/TEST06/README.md
+++ b/compliance/nvidia/TEST06/README.md
@@ -1,0 +1,48 @@
+# Test 06 - Verify consistency of the output of the Llama-v2-70b
+This repository provides the config files and scripts to run and verify TEST 06 - Verify consistency of the Llama-v2-70b output.
+
+# Table of contents
+1. [Introduction](#introduction)
+2. [Requisites](#Requisites)
+2. [Instructions](#instructions)
+
+## Introduction
+
+The purpose of this test is to ensure the consistency of the output of the Llama2 model and avoid a potential EOS exploit. This test will make a performance run, with a limit of 100 samples and logging them into `mlperf_log_accuracy.json`. To achieve a passing result in this test, two criteria must be met:
+- In the case the first token is reported independently (not applicable for Offline scenario), it should match for every query with the first token of the model output.
+- For each query, the model output should only end with zero or one EOS token
+
+## Requisites
+
+For this test, you need to be able to run the `Llama2-70b` benchmark. Therefore all it's requirements are also required for this test. Additionally, you need to have `numpy` installed.
+```
+pip install numpy
+```
+
+## Instructions
+### Part I
+Run the Llama-v2-70b benchmark with the provided audit.config in the corresponding subdirectory. Note that audit.config must be copied to the directory where the benchmark is being run from. Verification that audit.config was properly read can be done by checking that loadgen has found audit.config in mlperf_log_detail.txt
+
+### Part II
+Run the verification script
+```
+python3 run_verification.py -c COMPLIANCE_DIR -o OUTPUT_DIR -s SCENARIO
+```
+- COMPLIANCE_DIR: Specifies the path to the directory containing the logs from the compliance test run. 
+- OUTPUT_DIR: Specifies the path to the output directory where compliance logs will be uploaded from,   i.e. `inference_results_v0.7/closed/NVIDIA/compliance/TEST06/llama2-70b/Offline`
+- SCENARIO: Specifies the scenario the benchmark was run. One of ["Offline", "Server", "SingleStream", "MultiStream"]
+
+Expected output
+```
+First token check pass: True                
+EOS check pass: True             
+TEST06 verification complete   
+```
+
+Or:
+
+```
+First token check pass: Skipped                
+EOS check pass: True             
+TEST06 verification complete     
+```

--- a/compliance/nvidia/TEST06/audit.config
+++ b/compliance/nvidia/TEST06/audit.config
@@ -1,0 +1,11 @@
+# The format of this config file is 'key = value'.
+# The key has the format 'model.scenario.key'. Value is mostly int64_t.
+# Model maybe '*' as wildcard. In that case the value applies to all models.
+# All times are in milli seconds
+
+# mode dictionary (0 = submission, 1 = accuracy, 2 = performance, 3 = find peak perf)
+*.*.mode = 2
+*.*.accuracy_log_rng_seed = 720381539243781796
+*.*.accuracy_log_sampling_target = 100
+*.*.min_query_count = 100
+*.*.min_duration = 0

--- a/compliance/nvidia/TEST06/run_verification.py
+++ b/compliance/nvidia/TEST06/run_verification.py
@@ -1,0 +1,128 @@
+#! /usr/bin/env python3
+# Copyright 2018-2022 The MLPerf Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+import os
+import sys
+import shutil
+import argparse
+import json
+
+import numpy as np
+
+EOS_TOKEN = 2
+DTYPE_MAP = {
+    "int64": np.int64,
+    "int32": np.int32,
+    "int16": np.int16,
+    "float32": np.float32
+}
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compliance_dir", "-c", 
+                        help="Specifies the path to the directory containing the logs from the compliance test run.",
+                        required=True)
+    parser.add_argument("--output_dir", "-o",
+                        help="Specifies the path to the output directory where compliance logs will be uploaded from, i.e. inference_results_v0.7/closed/NVIDIA/compliance/T4x8/resnet/Offline.",
+                        required=True)
+    parser.add_argument("--dtype", "-d", default="int64", choices=["int64", "int32", "int16", "float32"])
+    parser.add_argument("--scenario", "-s", required=True, choices=["Offline", "Server", "SingleStream", "MultiStream"])
+    args = parser.parse_args()
+    return args
+
+def eos_check(acc_data, dtype):
+    for sample in acc_data:
+        data = np.frombuffer(bytes.fromhex(sample["data"]), dtype=dtype)
+        i = data.shape[0] - 1
+        n_eos_tokens = 0
+        while (i > 0):
+            if data[i] == EOS_TOKEN:
+                n_eos_tokens += 1
+            if n_eos_tokens >= 2:
+                return False
+            if data[i] != EOS_TOKEN:
+                break
+            i-=1
+    return True
+
+def first_token_check(acc_data, dtype):
+    for sample in acc_data:
+        data = np.frombuffer(bytes.fromhex(sample["data"]), dtype=dtype)
+        token_data = np.frombuffer(bytes.fromhex(sample["token_data"]), dtype=dtype)
+        print(token_data)
+        for t1, t2 in zip(data, token_data):
+            if t1 != t2:
+                return False
+        
+    return True
+
+def main():
+    args = get_args()
+    accuracy_file = os.path.join(args.compliance_dir, "mlperf_log_accuracy.json")
+    
+    with open(accuracy_file, "r") as acc_json:
+        acc_data = json.load(acc_json)
+    
+    try:
+        eos_pass = eos_check(acc_data, DTYPE_MAP[args.dtype])
+    except Exception:
+        print("Unexpected error occured while doing the EOS check")
+        eos_pass = False
+
+    need_first_token_check = (args.scenario != "Offline")
+    first_token_pass = True
+    if need_first_token_check:
+        try:
+            first_token_pass = first_token_check(acc_data, DTYPE_MAP[args.dtype])
+        except Exception:
+            print("Unexpected error occured while doing the first token check")
+            first_token_pass = False
+
+    # Construct output based on the results of checks
+    output = ""
+    # Add first token check
+    if need_first_token_check:
+        output += f"First token check pass: {first_token_pass}\n"
+    else:
+        output += f"First token check pass: Skipped\n"
+    
+    # Add EOS check
+    output += f"EOS check pass: {eos_pass}\n"
+
+    if eos_pass and first_token_pass:
+        output += "TEST06 verification complete\n"
+    else:
+        output += "TEST06 verification failed\n"
+
+    # Output test output to console and folder
+    output_dir = args.output_dir
+    output_accuracy_dir = os.path.join(args.output_dir, "accuracy")
+    
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    if not os.path.isdir(output_accuracy_dir):
+        os.makedirs(output_accuracy_dir)
+
+    with open(os.path.join(output_dir, "verify_accuracy.txt"), "w") as f:
+        f.write(output)
+
+    try:
+        shutil.copy2(accuracy_file,output_accuracy_dir)
+    except Exception:
+        print("Exception occured trying to copy " + accuracy_file + " to " + output_accuracy_dir)
+    print(output)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add Llama2 specific test to check the consistency of the model output
- Check that there is only 1 or 0 EOS tokens
- Check that the reported first token matches with the first token of the model output (only for applicable scenarios where `FirstTokenComplete` is called