### PR TITLE
Use left padding instead of right padding for BS>1 on Llama v2

### DIFF
--- a/language/llama2-70b/SUT.py
+++ b/language/llama2-70b/SUT.py
@@ -179,10 +179,10 @@ class SUT():
                 input_len = []
                 for q in qitem:
                     input_ids_tensor.append(pad(self.data_object.input_ids[q.index],
-                                                (0, max_seq_len - self.data_object.input_lens[q.index], 0, 0),
+                                                (max_seq_len - self.data_object.input_lens[q.index], 0, 0, 0),
                                                 value=self.tokenizer.pad_token_id))
                     input_masks_tensor.append(pad(self.data_object.attention_masks[q.index],
-                                                  (0, max_seq_len - self.data_object.input_lens[q.index], 0, 0),
+                                                  (max_seq_len - self.data_object.input_lens[q.index], 0, 0, 0),
                                                  value=0))
                     input_len.append(self.data_object.input_lens[q.index])
                 input_ids_tensor = torch.cat(input_ids_tensor)


### PR DESCRIPTION
Fixes https://github.com/mlcommons/inference/issues/1558

Running on a sample count of 100 showed an increase of Rouge scores from
```
{'rouge1': 46.799, 'rouge2': 24.0965, 'rougeL': 30.7241, 'rougeLsum': 44.3092, 'gen_len': 91291, 'gen_num': 100}
```
to
```
{'rouge1': 47.6373, 'rouge2': 25.5539, 'rougeL': 32.0018, 'rougeLsum': 45.2576, 'gen_len': 97811, 'gen_num': 100}
```