### PR TITLE
Fix loadgen token metrics latency constrains

### DIFF
--- a/language/llama2-70b/user.conf
+++ b/language/llama2-70b/user.conf
@@ -9,3 +9,5 @@
 *.Server.target_qps = 0.5
 *.Server.min_duration = 120000
 *.Server.min_query_count = 100
+
+llama2-70b.Server.sample_concatenate_permutation = 1

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -529,6 +529,9 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
   std::vector<QuerySampleLatency> first_token_latencies(
     GlobalLogger().GetTokenLatencies(expected_latencies));
 
+  std::vector<QuerySampleLatency> time_per_output_token_arr(
+    GlobalLogger().GetTimePerOutputToken(expected_latencies));
+
   std::vector<int64_t> tokens_per_sample(
     GlobalLogger().GetTokensPerSample(expected_latencies));
 
@@ -588,6 +591,7 @@ PerformanceResult IssueQueries(SystemUnderTest* sut,
                           final_query_all_samples_done_time,
                           TokenPerformanceResults{
                             first_token_latencies,
+                            time_per_output_token_arr,
                             tokens_per_sample
                           }
                         };

--- a/loadgen/logging.cc
+++ b/loadgen/logging.cc
@@ -349,6 +349,7 @@ void AsyncLog::RestartLatencyRecording(uint64_t first_sample_sequence_id,
   latencies_.reserve(latencies_to_reserve);
   token_latencies_.reserve(latencies_to_reserve);
   tokens_per_sample_.reserve(latencies_to_reserve);
+  time_per_output_token_.reserve(latencies_to_reserve);
 }
 
 void AsyncLog::RecordSampleCompletion(uint64_t sample_sequence_id,
@@ -430,15 +431,40 @@ void AsyncLog::RecordSampleCompletion(uint64_t sample_sequence_id,
       // If the SUT recorded the wrong sample, the test will hang and see
       // the error above.
       return;
-    } else if (n_tokens == 0){
+    } 
+    if (n_tokens == 0){
       MLPERF_LOG_ERROR_SYNC(GlobalLogger(), "error_runtime",
                             "n_tokens argument missing or attempted to record 0 as number of tokens");
     } else if (n_tokens < 0){
       MLPERF_LOG_ERROR_SYNC(GlobalLogger(), "error_runtime",
                             "Attempted to record a negative number of tokens");
       n_tokens = 0;
+    } else if (n_tokens == 1){
+      MLPERF_LOG_ERROR_SYNC(GlobalLogger(), "error_runtime",
+                            "Number of tokens need to be greater than 1");
+      n_tokens = 0;
+    }
+    if (time_per_output_token_.size() <= i){
+      time_per_output_token_.resize(i + 1, kInvalidLatency);
+    } else if (time_per_output_token_[i] != kInvalidLatency) {
+      // Call LogErrorSync here since this kind of error could result in a
+      // segfault in the near future.
+  #if USE_NEW_LOGGING_FORMAT
+      MLPERF_LOG_ERROR_SYNC(GlobalLogger(), "error_runtime",
+                            "Attempted to complete a sample twice.");
+  #else
+      GlobalLogger().LogErrorSync("Attempted to complete a sample twice.");
+  #endif
+
+      // Return without recording the latency again to avoid potentially
+      // ending the test before the SUT is actually done, which could result
+      // in a segfault.
+      // If the SUT recorded the wrong sample, the test will hang and see
+      // the error above.
+      return;
     }
     tokens_per_sample_[i] = n_tokens;
+    time_per_output_token_[i] = (latency - token_latencies_[i]) / (n_tokens - 1);
   }
   latencies_[i] = latency;
   latencies_recorded_++;
@@ -570,6 +596,12 @@ std::vector<QuerySampleLatency> AsyncLog::GetTokenLatencies(size_t expected_coun
   std::vector<QuerySampleLatency> token_latencies;
   token_latencies.swap(token_latencies_);
   return token_latencies;
+}
+
+std::vector<QuerySampleLatency> AsyncLog::GetTimePerOutputToken(size_t expected_count){
+  std::vector<QuerySampleLatency> tpot_latencies;
+  tpot_latencies.swap(time_per_output_token_);
+  return tpot_latencies;
 }
 
 std::vector<int64_t> AsyncLog::GetTokensPerSample(size_t expected_count) {
@@ -907,6 +939,10 @@ std::vector<QuerySampleLatency> Logger::GetLatenciesBlocking(
 std::vector<QuerySampleLatency> Logger::GetTokenLatencies(
     size_t expected_count) {
   return async_logger_.GetTokenLatencies(expected_count);
+}
+std::vector<QuerySampleLatency> Logger::GetTimePerOutputToken(
+    size_t expected_count) {
+  return async_logger_.GetTimePerOutputToken(expected_count);
 }
 std::vector<QuerySampleLatency> Logger::GetTokensPerSample(
     size_t expected_count) {

--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -322,6 +322,7 @@ class AsyncLog {
                               QuerySampleLatency latency);
   std::vector<QuerySampleLatency> GetLatenciesBlocking(size_t expected_count);
   std::vector<QuerySampleLatency> GetTokenLatencies(size_t expected_count);
+  std::vector<QuerySampleLatency> GetTimePerOutputToken(size_t expected_count);
   std::vector<int64_t> GetTokensPerSample(size_t expected_count);
   PerfClock::time_point GetMaxCompletionTime();
   QuerySampleLatency GetMaxLatencySoFar();
@@ -386,6 +387,7 @@ class AsyncLog {
   uint64_t latencies_first_sample_sequence_id_ = 0;
   std::vector<QuerySampleLatency> latencies_;
   std::vector<QuerySampleLatency> token_latencies_;
+  std::vector<QuerySampleLatency> time_per_output_token_;
   std::vector<LogBinaryAsHexString> token_records_;
   std::vector<int64_t> tokens_per_sample_;
   QuerySampleLatency max_latency_ = 0;
@@ -421,6 +423,7 @@ class Logger {
                                size_t latencies_to_reserve);
   std::vector<QuerySampleLatency> GetLatenciesBlocking(size_t expected_count);
   std::vector<QuerySampleLatency> GetTokenLatencies(size_t expected_count);
+  std::vector<QuerySampleLatency> GetTimePerOutputToken(size_t expected_count);
   std::vector<int64_t> GetTokensPerSample(size_t expected_count);
   PerfClock::time_point GetMaxCompletionTime();
   QuerySampleLatency GetMaxLatencySoFar();

--- a/loadgen/results.cc
+++ b/loadgen/results.cc
@@ -97,8 +97,15 @@ void PerformanceSummary::ProcessTokenLatencies() {
     accumulated_first_token_latency += latency;
   }
   first_token_latency_mean = accumulated_first_token_latency / sample_count;
+  QuerySampleLatency accumulated_tpot = 0;
+  for (auto latency : pr.token_results.time_per_output_token_arr) {
+    accumulated_tpot += latency;
+  }
+  time_per_output_token_mean = accumulated_tpot / sample_count;
   std::sort(pr.token_results.first_token_latencies.begin(), 
     pr.token_results.first_token_latencies.end());
+  std::sort(pr.token_results.time_per_output_token_arr.begin(),
+    pr.token_results.time_per_output_token_arr.end());
   
   token_target_latency_percentile.sample_latency =
       pr.token_results.first_token_latencies[sample_count * token_target_latency_percentile.percentile];
@@ -108,6 +115,16 @@ void PerformanceSummary::ProcessTokenLatencies() {
     assert(lp.percentile >= 0.0);
     assert(lp.percentile < 1.0);
     lp.sample_latency = pr.token_results.first_token_latencies[sample_count * lp.percentile];
+  }
+
+  target_tpot_percentile.sample_latency =
+      pr.token_results.time_per_output_token_arr[sample_count * token_target_latency_percentile.percentile];
+  time_per_output_token_min = pr.token_results.time_per_output_token_arr.front();
+  time_per_output_token_max = pr.token_results.time_per_output_token_arr.back();
+  for (auto& lp : tpot_percentiles) {
+    assert(lp.percentile >= 0.0);
+    assert(lp.percentile < 1.0);
+    lp.sample_latency = pr.token_results.time_per_output_token_arr[sample_count * lp.percentile];
   }
 
   if (settings.scenario == TestScenario::Server) {
@@ -121,10 +138,12 @@ void PerformanceSummary::ProcessTokenLatencies() {
 
 }
 
-bool PerformanceSummary::EarlyStopping(std::string* recommendation) {
+bool PerformanceSummary::EarlyStopping(std::string* recommendation, int64_t queries_issued, 
+                                        std::vector<QuerySampleLatency>* sample_latencies,
+                                        std::vector<QuerySampleLatency>* query_latencies,
+                                        std::chrono::nanoseconds target_latency) {
   recommendation->clear();
 
-  int64_t queries_issued = pr.queries_issued;
   MinPassingQueriesFinder find_min_passing;
   double confidence = 0.99;
   double tolerance = 0.0;
@@ -155,7 +174,7 @@ bool PerformanceSummary::EarlyStopping(std::string* recommendation) {
         }
       }
       QuerySampleLatency percentile_estimate =
-          pr.sample_latencies[queries_issued - t];
+          (*sample_latencies)[queries_issued - t];
       *recommendation =
           " * Processed at least " + std::to_string(h_min + 1) + " queries (" +
           std::to_string(queries_issued) + ").\n" + " * Would discard " +
@@ -187,7 +206,7 @@ bool PerformanceSummary::EarlyStopping(std::string* recommendation) {
             break;
           }
         }
-        percentile_estimate = pr.sample_latencies[queries_issued - t];
+        percentile_estimate = (*sample_latencies)[queries_issued - t];
         *recommendation +=
             "\n * Early stopping " +
             DoubleToString(multi_stream_percentile * 100, 0) +
@@ -198,9 +217,9 @@ bool PerformanceSummary::EarlyStopping(std::string* recommendation) {
     }
     case TestScenario::Server: {
       int64_t t =
-          std::count_if(pr.sample_latencies.begin(), pr.sample_latencies.end(),
+          std::count_if((*sample_latencies).begin(), (*sample_latencies).end(),
                         [=](auto const& latency) {
-                          return latency > settings.target_latency.count();
+                          return latency > target_latency.count();
                         });
       int64_t h = find_min_passing(t, target_latency_percentile.percentile,
                                    tolerance, confidence);
@@ -239,7 +258,7 @@ bool PerformanceSummary::EarlyStopping(std::string* recommendation) {
         }
       }
       QuerySampleLatency percentile_estimate =
-          pr.query_latencies[queries_issued - t];
+          (*query_latencies)[queries_issued - t];
       *recommendation =
           " * Processed at least " + std::to_string(h_min + 1) + " queries (" +
           std::to_string(queries_issued) + ").\n" + " * Would discard " +
@@ -400,10 +419,30 @@ void PerformanceSummary::LogSummary(AsyncSummary& summary) {
   std::string min_duration_recommendation;
   std::string perf_constraints_recommendation;
   std::string early_stopping_recommendation;
+  std::string early_stopping_ttft_recommendation;
+  std::string early_stopping_tpot_recommendation;
 
   bool min_duration_met = MinDurationMet(&min_duration_recommendation);
   bool min_queries_met = MinQueriesMet() && MinSamplesMet();
-  bool early_stopping_met = EarlyStopping(&early_stopping_recommendation);
+  bool early_stopping_met = true;
+  if (!settings.use_token_latencies){
+    early_stopping_met = EarlyStopping(&early_stopping_recommendation,
+                                        pr.queries_issued, 
+                                        &pr.sample_latencies, 
+                                        &pr.query_latencies,
+                                        settings.target_latency);
+  } else {
+    early_stopping_met = EarlyStopping(&early_stopping_tpot_recommendation,
+                                        pr.queries_issued, 
+                                        &pr.token_results.time_per_output_token_arr, 
+                                        &pr.query_latencies,
+                                        std::chrono::nanoseconds(settings.server_tpot_latency)) && 
+                          EarlyStopping(&early_stopping_ttft_recommendation,
+                                        pr.queries_issued, 
+                                        &pr.token_results.first_token_latencies, 
+                                        &pr.query_latencies,
+                                        std::chrono::nanoseconds(settings.server_ttft_latency));
+  }
   bool perf_constraints_met =
       PerfConstraintsMet(&perf_constraints_recommendation);
   bool all_constraints_met = min_duration_met && min_queries_met &&
@@ -435,8 +474,15 @@ void PerformanceSummary::LogSummary(AsyncSummary& summary) {
   if (settings.scenario == TestScenario::SingleStream ||
       settings.scenario == TestScenario::Server ||
       settings.scenario == TestScenario::MultiStream) {
-    summary("Early Stopping Result:");
-    summary(early_stopping_recommendation);
+    if (!settings.use_token_latencies){
+      summary("Early Stopping Result:");
+      summary(early_stopping_recommendation);
+    } else {
+      summary("TTFT Early Stopping Result:");
+      summary(early_stopping_ttft_recommendation);
+      summary("TPOT Early Stopping Result:");
+      summary(early_stopping_tpot_recommendation);
+    }
   }
 
   summary(
@@ -490,17 +536,26 @@ void PerformanceSummary::LogSummary(AsyncSummary& summary) {
     } else if (settings.scenario == TestScenario::Server) {
       double tps_as_completed =
           token_count / pr.final_query_all_samples_done_time;
-      summary("Completed tokens per second    : ",
+      summary("Completed tokens per second                 : ",
               DoubleToString(tps_as_completed));
     }
 
     if (settings.scenario != TestScenario::Offline) {
-      summary("Min First Token latency (ns)    : ", first_token_latency_min);
-      summary("Max First Token latency (ns)    : ", first_token_latency_max);
-      summary("Mean First Token latency (ns)   : ", first_token_latency_mean);
+      summary("Min First Token latency (ns)                : ", first_token_latency_min);
+      summary("Max First Token latency (ns)                : ", first_token_latency_max);
+      summary("Mean First Token latency (ns)               : ", first_token_latency_mean);
       for (auto& lp : token_latency_percentiles) {
         summary(
-            DoubleToString(lp.percentile * 100) + " percentile latency (ns)   : ",
+            DoubleToString(lp.percentile * 100) + " percentile first token latency (ns)   : ",
+            lp.sample_latency);
+      }
+      summary("");
+      summary("Min Time to Output Token (ns)                : ", time_per_output_token_min);
+      summary("Max Time to Output Token (ns)                : ", time_per_output_token_max);
+      summary("Mean Time to Output Token (ns)               : ", time_per_output_token_mean);
+      for (auto& lp : tpot_percentiles) {
+        summary(
+            DoubleToString(lp.percentile * 100) + " percentile time to output token (ns)   : ",
             lp.sample_latency);
       }
     }
@@ -522,11 +577,31 @@ void PerformanceSummary::LogDetail(AsyncDetail& detail) {
   std::string min_duration_recommendation;
   std::string perf_constraints_recommendation;
   std::string early_stopping_recommendation;
+  std::string early_stopping_ttft_recommendation;
+  std::string early_stopping_tpot_recommendation;
   bool min_duration_met = MinDurationMet(&min_duration_recommendation);
   bool min_queries_met = MinQueriesMet() && MinSamplesMet();
   bool perf_constraints_met =
       PerfConstraintsMet(&perf_constraints_recommendation);
-  bool early_stopping_met = EarlyStopping(&early_stopping_recommendation);
+  bool early_stopping_met = true;
+  if (!settings.use_token_latencies){
+    early_stopping_met = EarlyStopping(&early_stopping_recommendation,
+                                        pr.queries_issued, 
+                                        &pr.sample_latencies, 
+                                        &pr.query_latencies,
+                                        settings.target_latency);
+  } else {
+    early_stopping_met = EarlyStopping(&early_stopping_tpot_recommendation,
+                                        pr.queries_issued, 
+                                        &pr.token_results.time_per_output_token_arr, 
+                                        &pr.query_latencies,
+                                        std::chrono::nanoseconds(settings.server_tpot_latency)) && 
+                          EarlyStopping(&early_stopping_ttft_recommendation,
+                                        pr.queries_issued, 
+                                        &pr.token_results.first_token_latencies, 
+                                        &pr.query_latencies,
+                                        std::chrono::nanoseconds(settings.server_ttft_latency));
+  }
   bool all_constraints_met = min_duration_met && min_queries_met &&
                              perf_constraints_met && early_stopping_met;
 
@@ -554,8 +629,12 @@ void PerformanceSummary::LogDetail(AsyncDetail& detail) {
   }
   std::replace(early_stopping_recommendation.begin(),
                early_stopping_recommendation.end(), '\n', ' ');
-  MLPERF_LOG(detail, "early_stopping_result", early_stopping_recommendation);
-
+  if (!settings.use_token_latencies){
+    MLPERF_LOG(detail, "early_stopping_result", early_stopping_recommendation);
+  } else{
+    MLPERF_LOG(detail, "early_stopping_ttft_result", early_stopping_ttft_recommendation);
+    MLPERF_LOG(detail, "early_stopping_tpot_result", early_stopping_tpot_recommendation);
+  }
   // Report number of queries
   MLPERF_LOG(detail, "result_query_count", query_count);
   if (settings.scenario == TestScenario::Server) {
@@ -639,25 +718,20 @@ void PerformanceSummary::LogDetail(AsyncDetail& detail) {
                     "result_first_token_" + DoubleToString(lp.percentile * 100) +
                         "_percentile_latency_ns",
                     lp.sample_latency);
-        if ((lp.percentile == .999) & (lp.sample_latency > settings.server_ttft_latency)){
-          MLPERF_LOG_WARNING(detail, "warning_generic_message", 
-            "Value for result_first_token_" + DoubleToString(lp.percentile * 100) +
-            "_percentile_latency_ns greater than target time_to_first_token"
-          );
-        }
       }
       double tps_w_lg = ((double)token_count) / pr.final_query_issued_time;
       double tps_wo_lg= ((double)token_count) / (sample_latency_mean * sample_count);
       MLPERF_LOG(detail, "result_token_throughput_with_loadgen_overhead", tps_w_lg);
       MLPERF_LOG(detail, "result_token_throughput", tps_wo_lg);
-      uint64_t tpot = sample_count * (sample_latency_mean - first_token_latency_mean) / (token_count);
-      MLPERF_LOG(detail, "result_time_to_output_token", tpot);
-      if (tpot > settings.server_tpot_latency){
-        MLPERF_LOG_WARNING(detail, "warning_generic_message",
-          "Value for result_time_to_output_token "
-          "greater than target time_to_output_token"
-        );
+      for (auto& lp : tpot_percentiles) {
+        MLPERF_LOG(detail,
+                    "result_time_per_output_token_" + DoubleToString(lp.percentile * 100) +
+                        "_percentile_ns",
+                    lp.sample_latency);
       }
+      MLPERF_LOG(detail, "result_time_to_output_token_min", time_per_output_token_min);
+      MLPERF_LOG(detail, "result_time_to_output_token_max", time_per_output_token_max);
+      MLPERF_LOG(detail, "result_time_to_output_token_mean", time_per_output_token_mean);
     } else {
       double tokens_per_second = token_count / pr.max_latency;
       MLPERF_LOG(detail, "result_tokens_per_second", tokens_per_second);

--- a/loadgen/results.h
+++ b/loadgen/results.h
@@ -29,6 +29,7 @@ namespace loadgen {
 /// token based metrics
 struct TokenPerformanceResults {
   std::vector<QuerySampleLatency> first_token_latencies;
+  std::vector<QuerySampleLatency> time_per_output_token_arr;
   std::vector<int64_t> tokens_per_sample;
 };
 
@@ -86,11 +87,17 @@ struct PerformanceSummary {
   QuerySampleLatency first_token_latency_min;
   QuerySampleLatency first_token_latency_max;
   QuerySampleLatency first_token_latency_mean;
+  QuerySampleLatency time_per_output_token_min;
+  QuerySampleLatency time_per_output_token_max;
+  QuerySampleLatency time_per_output_token_mean;
 
   // Latency token target percentile
   PercentileEntry token_target_latency_percentile{settings.target_latency_percentile};
   PercentileEntry token_latency_percentiles[6] = {{.50}, {.90}, {.95},
                                                   {.97}, {.99}, {.999}};
+  PercentileEntry target_tpot_percentile{settings.target_latency_percentile};
+  PercentileEntry tpot_percentiles[6] = {{.50}, {.90}, {.95},
+                                        {.97}, {.99}, {.999}};
 
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
   // MSVC complains if there is no explicit constructor.
@@ -104,7 +111,10 @@ struct PerformanceSummary {
   void ProcessTokenLatencies();
 
   bool MinDurationMet(std::string* recommendation);
-  bool EarlyStopping(std::string* recommendation);
+  bool EarlyStopping(std::string* recommendation, int64_t queries_issued, 
+                      std::vector<QuerySampleLatency>* sample_latencies,
+                      std::vector<QuerySampleLatency>* query_latencies,
+                      std::chrono::nanoseconds target_latency);
   bool MinQueriesMet();
   bool MinSamplesMet();
   bool HasPerfConstraints();

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -482,7 +482,12 @@ void TestSettingsInternal::LogAllSettings() const {
 void TestSettingsInternal::LogSummary(AsyncSummary &summary) const {
   summary("samples_per_query : ", samples_per_query);
   summary("target_qps : ", target_qps);
-  summary("target_latency (ns): ", target_latency.count());
+  if (!use_token_latencies){
+    summary("target_latency (ns): ", target_latency.count());
+  } else {
+    summary("ttft_latency (ns): ", server_ttft_latency);
+    summary("tpot_latency (ns): ", server_tpot_latency);
+  }
   summary("max_async_queries : ", max_async_queries);
   summary("min_duration (ms): ", min_duration.count());
   summary("max_duration (ms): ", max_duration.count());

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -59,7 +59,8 @@ gptj.Server.target_latency = 20000
 stable-diffusion-xl.Server.target_latency = 20000
 # Falcon Server scenario requires two latency constraints
 llama2-70b.*.use_token_latencies = 1
-llama2-70b.Server.target_latency = 2000
+# Only ttft and tpot are tracked for the llama2-70b benchmark therefore target_latency = 0
+llama2-70b.Server.target_latency = 0
 llama2-70b.Server.ttft_latency = 2000
 llama2-70b.Server.tpot_latency = 200
 

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -43,6 +43,7 @@ retinanet.MultiStream.target_latency = 528
 
 # GPT-J uses equal issue mode for Single-Stream
 gptj.SingleStream.sample_concatenate_permutation = 1
+gptj.Server.sample_concatenate_permutation = 1
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99


### PR DESCRIPTION
Fix #1593 
Changes in this PR:
- Remove warnings with incorrect comparison
- Run early stopping checks for ttft and tpot recorded values and their respective target latencies (only when using using loadgen with token metrics)
- Avoid running early stopping checks for the sample latencies when measuring token metrics
