### PR TITLE
Add sample length check to test06

### DIFF
--- a/compliance/nvidia/TEST06/README.md
+++ b/compliance/nvidia/TEST06/README.md
@@ -11,7 +11,7 @@ This repository provides the config files and scripts to run and verify TEST 06 
 The purpose of this test is to ensure the consistency of the output of the Llama2 model and avoid a potential EOS exploit. This test will make a performance run, with a limit of 100 samples and logging them into `mlperf_log_accuracy.json`. To achieve a passing result in this test, three criteria must be met:
 - In the case the first token is reported independently (not applicable for Offline scenario), it should match for every query with the first token of the model output.
 - For each query, the model output should only end with zero or one EOS token
-- The number of reported tokens should match with the lenght of it's
+- The number of reported tokens should match with the length of it's
 
 ## Requisites
 
@@ -37,7 +37,7 @@ Expected output
 ```
 First token check pass: True                
 EOS check pass: True             
-Sample lenght check pass: True  
+Sample length check pass: True  
 TEST06 verification complete   
 ```
 
@@ -46,6 +46,6 @@ Or:
 ```
 First token check pass: Skipped                
 EOS check pass: True             
-Sample lenght check pass: True  
+Sample length check pass: True  
 TEST06 verification complete     
 ```

--- a/compliance/nvidia/TEST06/README.md
+++ b/compliance/nvidia/TEST06/README.md
@@ -8,9 +8,10 @@ This repository provides the config files and scripts to run and verify TEST 06 
 
 ## Introduction
 
-The purpose of this test is to ensure the consistency of the output of the Llama2 model and avoid a potential EOS exploit. This test will make a performance run, with a limit of 100 samples and logging them into `mlperf_log_accuracy.json`. To achieve a passing result in this test, two criteria must be met:
+The purpose of this test is to ensure the consistency of the output of the Llama2 model and avoid a potential EOS exploit. This test will make a performance run, with a limit of 100 samples and logging them into `mlperf_log_accuracy.json`. To achieve a passing result in this test, three criteria must be met:
 - In the case the first token is reported independently (not applicable for Offline scenario), it should match for every query with the first token of the model output.
 - For each query, the model output should only end with zero or one EOS token
+- The number of reported tokens should match with the lenght of it's
 
 ## Requisites
 
@@ -36,6 +37,7 @@ Expected output
 ```
 First token check pass: True                
 EOS check pass: True             
+Sample lenght check pass: True  
 TEST06 verification complete   
 ```
 
@@ -44,5 +46,6 @@ Or:
 ```
 First token check pass: Skipped                
 EOS check pass: True             
+Sample lenght check pass: True  
 TEST06 verification complete     
 ```

--- a/compliance/nvidia/TEST06/run_verification.py
+++ b/compliance/nvidia/TEST06/run_verification.py
@@ -112,7 +112,7 @@ def main():
     output += f"EOS check pass: {eos_pass}\n"
 
     # Add sample length check
-    output += f"Sample lenght check pass: {sample_len_pass}\n"
+    output += f"Sample length check pass: {sample_len_pass}\n"
 
     if eos_pass and first_token_pass and sample_len_pass:
         output += "TEST06 verification complete\n"

--- a/compliance/nvidia/TEST06/run_verification.py
+++ b/compliance/nvidia/TEST06/run_verification.py
@@ -67,6 +67,15 @@ def first_token_check(acc_data, dtype):
         
     return True
 
+def sample_len_check(acc_data, dtype):
+    for sample in acc_data:
+        data = np.frombuffer(bytes.fromhex(sample["data"]), dtype=dtype)
+        token_count = int(sample["token_count"])
+        if len(data) != token_count:
+            return False
+    return True
+
+
 def main():
     args = get_args()
     accuracy_file = os.path.join(args.compliance_dir, "mlperf_log_accuracy.json")
@@ -89,6 +98,8 @@ def main():
             print("Unexpected error occured while doing the first token check")
             first_token_pass = False
 
+    sample_len_pass = sample_len_check(acc_data, DTYPE_MAP[args.dtype])
+
     # Construct output based on the results of checks
     output = ""
     # Add first token check
@@ -100,7 +111,10 @@ def main():
     # Add EOS check
     output += f"EOS check pass: {eos_pass}\n"
 
-    if eos_pass and first_token_pass:
+    # Add sample length check
+    output += f"Sample lenght check pass: {sample_len_pass}\n"
+
+    if eos_pass and first_token_pass and sample_len_pass:
         output += "TEST06 verification complete\n"
     else:
         output += "TEST06 verification failed\n"

--- a/language/llama2-70b/README.md
+++ b/language/llama2-70b/README.md
@@ -4,7 +4,9 @@
 
 + Processing of Validation dataset is not finalized yet. Decision on input token lengths is pending
 + Streamer for communicating with loadgen has quite some overhead. This is only meant to provide functional implementation
-
++ For custom/optimized implementations of this benchmark it is important to include the :
+        - For server scenario, it is necesary to call `lg.FirstTokenComplete(response)` for each query. This way the first token will be reported and it's latency will be measured.
+        - For all scenarios, when calling `lg.QuerySamplesComplete(response)`, it is necessary that each of the elements in response is a `lg.QuerySampleResponse` that contains the number of tokens (can be create this way: `lg.QuerySampleResponse(qitem.id, bi[0], bi[1], n_tokens)`). The number of tokens reported should match with the number of tokens on your answer and this will be checked in [TEST06](../../compliance/nvidia/TEST06/)
 
 ## Prepare environment
 

--- a/language/llama2-70b/SUT.py
+++ b/language/llama2-70b/SUT.py
@@ -342,11 +342,11 @@ class SUTServer(SUT):
                                         )
 
             output_tokens = tokens_streamer.get_out_tokens()
-
+            n_tokens = len(output_tokens)
             response_array = array.array("B", np.array(output_tokens, np.int32).tobytes())
             bi = response_array.buffer_info()
             response = [lg.QuerySampleResponse(
-                qitem.id, bi[0], bi[1])]
+                qitem.id, bi[0], bi[1], n_tokens)]
             lg.QuerySamplesComplete(response)
 
 

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -120,7 +120,7 @@ struct ResponseDelegateDetailed : public ResponseDelegate {
 
       if (sample_data_copy) {
         log.LogAccuracy(sample->sequence_id, sample->sample_index,
-                        LogBinaryAsHexString{sample_data_copy});
+                        LogBinaryAsHexString{sample_data_copy}, n_tokens);
         delete sample_data_copy;
       }
 

--- a/loadgen/logging.cc
+++ b/loadgen/logging.cc
@@ -285,13 +285,19 @@ void AsyncLog::LogAccuracy(uint64_t seq_id, const QuerySampleIndex qsl_idx,
     return;
   }
   *accuracy_out_ << (accuracy_needs_comma_ ? ",\n{ " : "\n{ ");
-  if (!use_tokens_ || !needs_first_token_){
+  if (!use_tokens_){
     LogArgs(accuracy_out_, "seq_id", seq_id, "qsl_idx", qsl_idx, "data",
           response);
-  } else {
+  } else if (!needs_first_token_)
+  {
     const size_t i = seq_id - latencies_first_sample_sequence_id_;
     LogArgs(accuracy_out_, "seq_id", seq_id, "qsl_idx", qsl_idx, "data",
-          response, "token_data", token_records_[i]);
+          response, "token_count", tokens_per_sample_[i]);
+  }
+  else {
+    const size_t i = seq_id - latencies_first_sample_sequence_id_;
+    LogArgs(accuracy_out_, "seq_id", seq_id, "qsl_idx", qsl_idx, "data",
+          response, "token_data", token_records_[i], "token_count", tokens_per_sample_[i]);
   }
   
   *accuracy_out_ << " }";

--- a/loadgen/logging.cc
+++ b/loadgen/logging.cc
@@ -279,7 +279,8 @@ void AsyncLog::StopTrace() {
 }
 
 void AsyncLog::LogAccuracy(uint64_t seq_id, const QuerySampleIndex qsl_idx,
-                           const LogBinaryAsHexString& response) {
+                           const LogBinaryAsHexString& response,
+                           int64_t n_tokens = 0) {
   std::unique_lock<std::mutex> lock(log_mutex_);
   if (!accuracy_out_) {
     return;
@@ -290,14 +291,13 @@ void AsyncLog::LogAccuracy(uint64_t seq_id, const QuerySampleIndex qsl_idx,
           response);
   } else if (!needs_first_token_)
   {
-    const size_t i = seq_id - latencies_first_sample_sequence_id_;
     LogArgs(accuracy_out_, "seq_id", seq_id, "qsl_idx", qsl_idx, "data",
-          response, "token_count", tokens_per_sample_[i]);
+          response, "token_count", n_tokens);
   }
   else {
     const size_t i = seq_id - latencies_first_sample_sequence_id_;
     LogArgs(accuracy_out_, "seq_id", seq_id, "qsl_idx", qsl_idx, "data",
-          response, "token_data", token_records_[i], "token_count", tokens_per_sample_[i]);
+          response, "token_data", token_records_[i], "token_count", n_tokens);
   }
   
   *accuracy_out_ << " }";

--- a/loadgen/logging.h
+++ b/loadgen/logging.h
@@ -226,7 +226,7 @@ class AsyncLog {
   void SetCurrentPidTid(uint64_t pid, uint64_t tid);
 
   void LogAccuracy(uint64_t seq_id, const QuerySampleIndex qsl_idx,
-                   const LogBinaryAsHexString& response);
+                   const LogBinaryAsHexString& response, int64_t n_tokens);
   void CacheToken(uint64_t seq_id, const LogBinaryAsHexString& response);
 
   template <typename... Args>

--- a/loadgen/results.cc
+++ b/loadgen/results.cc
@@ -650,6 +650,10 @@ void PerformanceSummary::LogDetail(AsyncDetail& detail) {
   if (!settings.use_token_latencies){
     MLPERF_LOG(detail, "early_stopping_result", early_stopping_recommendation);
   } else{
+    std::replace(early_stopping_ttft_recommendation.begin(),
+               early_stopping_ttft_recommendation.end(), '\n', ' ');
+    std::replace(early_stopping_tpot_recommendation.begin(),
+                early_stopping_tpot_recommendation.end(), '\n', ' ');
     MLPERF_LOG(detail, "early_stopping_ttft_result", early_stopping_ttft_recommendation);
     MLPERF_LOG(detail, "early_stopping_tpot_result", early_stopping_tpot_recommendation);
   }


### PR DESCRIPTION
- Report number of tokens reported correctly in reference implementation
- Check that number of tokens matches with sample response in Test06
- Remove `\n` in `mlperf_log_detail.txt`