### PR TITLE
Enable equal issue mode for LLM benchmarks

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -316,9 +316,10 @@ std::vector<QueryMetadata> GenerateQueries(
   auto schedule_distribution =
       ScheduleDistribution<scenario>(settings.target_qps);
 
-  // When sample_concatenate_permutation is turned on, pad to a multiple of the
+  // When sample_concatenate_permutation is turned on for Offline mode, pad to a multiple of the
   // complete dataset to ensure complete fairness.
   if (settings.sample_concatenate_permutation &&
+      scenario == TestScenario::Offline &&
       samples_per_query % loaded_samples.size() != 0) {
     size_t pad_size =
         (loaded_samples.size() - samples_per_query % loaded_samples.size());

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -318,9 +318,7 @@ std::vector<QueryMetadata> GenerateQueries(
 
   // When sample_concatenate_permutation is turned on, pad to a multiple of the
   // complete dataset to ensure complete fairness.
-  // FIXME: Only override this for Offline; fix after v2.0
   if (settings.sample_concatenate_permutation &&
-      scenario == TestScenario::Offline &&
       samples_per_query % loaded_samples.size() != 0) {
     size_t pad_size =
         (loaded_samples.size() - samples_per_query % loaded_samples.size());
@@ -380,10 +378,7 @@ std::vector<QueryMetadata> GenerateQueries(
         }
       }
     } else {
-      // FIXME: only used for v2.0 3D-UNet KiTS19 SingleStream
-      // TODO: consolidate after v2.0
-      auto equal_issue = settings.sample_concatenate_permutation &&
-                         scenario == TestScenario::SingleStream;
+      auto equal_issue = settings.sample_concatenate_permutation;
       for (auto& s : samples) {
         s = loaded_samples[settings.performance_issue_unique
                            ? sample_distribution_unique(sample_rng)

--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -227,10 +227,8 @@ auto SampleDistribution<TestMode::PerformanceOnly>(size_t sample_count,
              auto& gen) mutable { return dist(gen); };
 }
 
-/// \brief SampleDistribution for 3D-UNet SingleStream, for v2.0
-// FIXME: meant for 3D UNet SingleStream only at the moment but the logic should
-// work for others
-// TODO: consolidate the distribution generator after v2.0
+/// \brief Sample across the dataset, and ensure coverage of each of the samples.
+// Useful for non-uniform dataset (e.g. Llama2, GPTJ, 3d-unet)
 auto SampleDistributionEqualIssue(size_t sample_count, size_t set_size,
                                   std::mt19937* rng) {
   std::vector<size_t> indices;

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -38,12 +38,16 @@ stable-diffusion-xl.*.performance_sample_count_override = 5000
 retinanet.MultiStream.target_latency = 528
 
 
-# 3D-UNet uses equal issue mode
+# 3D-UNet uses equal issue mode because it has non-uniform inputs
 3d-unet.*.sample_concatenate_permutation = 1
 
-# GPT-J uses equal issue mode for Single-Stream
-gptj.SingleStream.sample_concatenate_permutation = 1
+# LLM benchmarks have non-uniform inputs and outputs, and use equal issue mode for all latency scenario
 gptj.Server.sample_concatenate_permutation = 1
+gptj.SingleStream.sample_concatenate_permutation = 1
+gptj.MultiStream.sample_concatenate_permutation = 1
+llama2-70b.Server.sample_concatenate_permutation = 1
+llama2-70b.SingleStream.sample_concatenate_permutation = 1
+llama2-70b.MultiStream.sample_concatenate_permutation = 1
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -48,10 +48,7 @@ retinanet.MultiStream.target_latency = 528
 # LLM benchmarks have non-uniform inputs and outputs, and use equal issue mode for all latency scenario
 gptj.Server.sample_concatenate_permutation = 1
 gptj.SingleStream.sample_concatenate_permutation = 1
-gptj.MultiStream.sample_concatenate_permutation = 1
 llama2-70b.Server.sample_concatenate_permutation = 1
-llama2-70b.SingleStream.sample_concatenate_permutation = 1
-llama2-70b.MultiStream.sample_concatenate_permutation = 1
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -12,6 +12,8 @@ bert.*.performance_sample_count_override = 10833
 dlrm.*.performance_sample_count_override = 204800
 dlrm-v2.*.performance_sample_count_override = 204800
 rnnt.*.performance_sample_count_override = 2513
+gptj.*.performance_sample_count_override = 13368
+llama2-70b.*.performance_sample_count_override = 24576
 stable-diffusion-xl.*.performance_sample_count_override = 5000
 # set to 0 to let entire sample set to be performance sample
 3d-unet.*.performance_sample_count_override = 0
@@ -28,15 +30,17 @@ stable-diffusion-xl.*.performance_sample_count_override = 5000
 
 *.SingleStream.target_latency_percentile = 90
 *.SingleStream.min_duration = 600000
-#*.SingleStream.min_query_count = 1024
 
 *.MultiStream.target_latency_percentile = 99
 *.MultiStream.samples_per_query = 8
 *.MultiStream.min_duration = 600000
-#*.MultiStream.min_query_count = 270336
 *.MultiStream.min_query_count = 662
 retinanet.MultiStream.target_latency = 528
 
+# With early stopping enabled, the min_query_count is 1 for Server Scenario
+*.Server.min_query_count = 1
+*.SingleStream.min_query_count = 100
+*.MultiStream.min_query_count = 662
 
 # 3D-UNet uses equal issue mode because it has non-uniform inputs
 3d-unet.*.sample_concatenate_permutation = 1
@@ -53,7 +57,6 @@ llama2-70b.MultiStream.sample_concatenate_permutation = 1
 *.Server.target_latency_percentile = 99
 *.Server.target_duration = 0
 *.Server.min_duration = 600000
-#*.Server.min_query_count = 270336
 resnet50.Server.target_latency = 15
 retinanet.Server.target_latency = 100
 bert.Server.target_latency = 130

--- a/mlperf.conf
+++ b/mlperf.conf
@@ -37,11 +37,6 @@ stable-diffusion-xl.*.performance_sample_count_override = 5000
 *.MultiStream.min_query_count = 662
 retinanet.MultiStream.target_latency = 528
 
-# With early stopping enabled, the min_query_count is 1 for Server Scenario
-*.Server.min_query_count = 1
-*.SingleStream.min_query_count = 100
-*.MultiStream.min_query_count = 662
-
 # 3D-UNet uses equal issue mode because it has non-uniform inputs
 3d-unet.*.sample_concatenate_permutation = 1
 


### PR DESCRIPTION
LLM benchmarks have non-uniform input and outputs (due to variable token length). Thus for latency-sensitive scenarios, equal issue mode needs to be enabled:

- For Offline scenarios, the samples_per_query is padded to a multiple of the dataset size
- For all other scenarios, the min_queries is padded to a multiple of the dataset size, and the increment will be the dataset size if the latency or min_duration threshold is not met.

@pgmpablo157321 