### PR TITLE
Turn equal issue mode off for TEST06

### DIFF
--- a/compliance/nvidia/TEST06/audit.config
+++ b/compliance/nvidia/TEST06/audit.config
@@ -9,3 +9,5 @@
 *.*.accuracy_log_sampling_target = 100
 *.*.min_query_count = 100
 *.*.min_duration = 0
+# Turn off equal issue mode for TEST06
+*.*.sample_concatenate_permutation = 0

--- a/compliance/nvidia/TEST06/run_verification.py
+++ b/compliance/nvidia/TEST06/run_verification.py
@@ -120,7 +120,7 @@ def main():
         output += "TEST06 verification failed\n"
 
     # Output test output to console and folder
-    output_dir = args.output_dir
+    output_dir = os.path.join(args.output_dir, "TEST06")
     output_accuracy_dir = os.path.join(args.output_dir, "accuracy")
     
     if not os.path.isdir(output_dir):


### PR DESCRIPTION
Equal issue mode is not needed for TEST06 because it's an accuracy check, not performance check.
Otherwise the submission log will be too large for the audit test.
@pgmpablo157321 