### PR TITLE
Update power_checker.py SUPPORTED_VERSION

### DIFF
--- a/tools/submission/power/power_checker.py
+++ b/tools/submission/power/power_checker.py
@@ -39,7 +39,7 @@ class CheckerWarning(Exception):
     pass
 
 
-SUPPORTED_VERSION = ["1.10.0"]
+SUPPORTED_VERSION = ["1.11.0_prerelease"]
 SUPPORTED_MODEL = {
     "YokogawaWT210": 8,
     "YokogawaWT500": 35,


### PR DESCRIPTION
Update SUPPORTED_VERSION in power_checker.py to "1.11.0_prerelease" required for MLPerf  Inference v4.0.