### PR TITLE
Bugfix: equal-issue mode on offline causing accuracy run to fail (3D-UNet)

### DIFF
--- a/loadgen/loadgen.cc
+++ b/loadgen/loadgen.cc
@@ -315,7 +315,7 @@ std::vector<QueryMetadata> GenerateQueries(
   // When sample_concatenate_permutation is turned on, pad to a multiple of the
   // complete dataset to ensure fairness.
   auto enable_equal_issue = settings.sample_concatenate_permutation;
-  if (enable_equal_issue)
+  if (mode != TestMode::AccuracyOnly && enable_equal_issue)
   {
     if (scenario == TestScenario::Offline &&
       samples_per_query % loaded_samples.size() != 0)


### PR DESCRIPTION
Currently 3D-UNet is the only workload using equal-issue mode on Offline scenario.  

Recent code change on LLM equal-issue mode caused 3D-UNet accuracy run to run more than 1 queries, causing the accuracy log to bloat and fail the accuracy checking script. 

This change fixes the problem described above.

This needs to be merged ASAP and submitters would need to recollect 3D-UNet offline accuracy logs again (SingleStream is not impacted).