### PR TITLE
Hotfix: DLRMv2 Audit Test01 fallback failure

### DIFF
--- a/recommendation/dlrm_v2/pytorch/tools/accuracy-dlrm.py
+++ b/recommendation/dlrm_v2/pytorch/tools/accuracy-dlrm.py
@@ -43,7 +43,9 @@ def get_targets(args, qsl_indices):
     with open(args.aggregation_trace_file) as f:
         for line in f:
             sample_boundaries.append(sample_boundaries[-1] + int(line.split(", ")[2]))
-    assert len(sample_boundaries) == len(qsl_indices) + 1, "Number of samples in trace file does not match number of samples in loadgen accuracy log!"
+    if len(sample_boundaries) != len(qsl_indices) + 1:
+        print("Warning: number of samples in trace file ({}) does not match number of samples ({}) in "
+              "loadgen accuracy log!".format(len(sample_boundaries)-1, len(qsl_indicies)))
     # Get all the ground truth labels in the original order in day_23
     print("Parsing ground truth labels from day_23 file...")
     ground_truths = []

--- a/recommendation/dlrm_v2/pytorch/tools/accuracy-dlrm.py
+++ b/recommendation/dlrm_v2/pytorch/tools/accuracy-dlrm.py
@@ -45,7 +45,7 @@ def get_targets(args, qsl_indices):
             sample_boundaries.append(sample_boundaries[-1] + int(line.split(", ")[2]))
     if len(sample_boundaries) != len(qsl_indices) + 1:
         print("Warning: number of samples in trace file ({}) does not match number of samples ({}) in "
-              "loadgen accuracy log!".format(len(sample_boundaries)-1, len(qsl_indicies)))
+              "loadgen accuracy log!".format(len(sample_boundaries)-1, len(qsl_indices)))
     # Get all the ground truth labels in the original order in day_23
     print("Parsing ground truth labels from day_23 file...")
     ground_truths = []


### PR DESCRIPTION
DLRMv2 Audit TEST01 may go to fallback route and the accuracy check script (accuracy-dlrm.py) didn't expect this to happen. It always expects entire sample set to be in the accuracy log while Audit TEST01 would generate subset only.

This fixes the Audit TEST01 failure described above.

This needs to be merged ASAP.