### PR TITLE
Support running loadgen over the network with external SUTs

### DIFF
--- a/language/bert/run.py
+++ b/language/bert/run.py
@@ -124,7 +124,7 @@ def main():
         from network_SUT import app, node, set_backend
         node = args.node
         set_backend(sut)
-        app.run(debug=False, port=args.port)
+        app.run(debug=False, port=args.port, host="0.0.0.0")
 
     else:
         print("Running LoadGen test...")


### PR DESCRIPTION
Currently the loadgen over the network is connecting only to the same host. This fix makes it connect to external SUTs in the network.