### PR TITLE
Set v4.1 as the default version for the submission checker

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -783,7 +783,7 @@ def get_args():
     parser.add_argument("--input", required=True, help="submission directory")
     parser.add_argument(
         "--version",
-        default="v4.0",
+        default="v4.1",
         choices=list(MODEL_CONFIG.keys()),
         help="mlperf version",
     )


### PR DESCRIPTION
Fixes #1738.

Updating the default version for the upcoming v4.1 round to avoid hitting errors like:

```
[2024-06-20 15:48:09,294 submission_checker.py:1097 ERROR] closed/Krai/compliance/<...>/resnet50/offline/TEST05/performance/run_1/mlperf_log_detail.txt qsl_rng_seed is wrong, expected=2376919268182438552, found=16799458546791641818
```

(16799458546791641818 is [correct for v4.1](https://github.com/mlcommons/inference/blob/master/mlperf.conf#L26); 2376919268182438552 was [used for v4.0](https://github.com/mlcommons/inference/blob/ad25362ba4e6570e70723c4268262a6cb7f13cb8/mlperf.conf#L26).)