### PR TITLE
added batch size to SUT Server

### DIFF
--- a/language/llama2-70b/SUT.py
+++ b/language/llama2-70b/SUT.py
@@ -285,7 +285,7 @@ class SUT():
 
 
 class SUTServer(SUT):
-    def __init__(self, model_path=None, dtype="bfloat16", device="cpu", total_sample_count=24576, dataset_path=None, workers=1):
+    def __init__(self, model_path=None, dtype="bfloat16", device="cpu", total_sample_count=24576, dataset_path=None, batch_size=None, workers=1):
 
         super().__init__(model_path=model_path, dtype=dtype, device=device, total_sample_count=total_sample_count, dataset_path=dataset_path, workers=workers)
 


### PR DESCRIPTION
In this line, batch size is passed(https://github.com/mlcommons/inference/blob/2a46c7afb88b89a6c5def96953902793996ee37b/language/llama2-70b/main.py#L70) but the server scenario code does not have the batch size argument(https://github.com/mlcommons/inference/blob/2a46c7afb88b89a6c5def96953902793996ee37b/language/llama2-70b/SUT.py#L288)

This fails the workflow due to following error in server scenario:
```
Traceback (most recent call last):
  File "/home/anandhu/CM/repos/local/cache/aa85cd9ada244ffd/inference/language/llama2-70b/main.py", line 98, in <module>
    main()
  File "/home/anandhu/CM/repos/local/cache/aa85cd9ada244ffd/inference/language/llama2-70b/main.py", line 70, in main
    sut = sut_cls(
          ^^^^^^^^
TypeError: SUTServer.__init__() got an unexpected keyword argument 'batch_size'

```

To reproduce: 
```
cm run script --tags=run-mlperf,inference \
   --model=llama2-70b-99 \
   --implementation=reference \
   --framework=pytorch \
   --category=datacenter \
   --server_target_qps=1 \
   --execution_mode=valid \
   --device=cpu \
   --quiet
```
