### PR TITLE
Fix mixtral accuracy check run if there are no samples from openorca

### DIFF
--- a/language/mixtral-8x7b/evaluate-accuracy.py
+++ b/language/mixtral-8x7b/evaluate-accuracy.py
@@ -173,10 +173,17 @@ def main():
 
     preds, targets = postprocess_text(
         preds_decoded_text, target_required_OpenOrca)
-    result = metric.compute(
-        predictions=preds, references=targets, use_stemmer=True, use_aggregator=False)
-    result = {k: round(np.mean(v) * 100, 4) for k, v in result.items()}
-    prediction_lens = [len(pred) for pred in preds]
+    
+    if preds:
+        result = metric.compute(
+            predictions=preds, references=targets, use_stemmer=True, use_aggregator=False)
+        result = {k: round(np.mean(v) * 100, 4) for k, v in result.items()}
+        prediction_lens = [len(pred) for pred in preds]
+
+    else:
+        result = {}
+        prediction_lens = []
+
     # GSM8K metric
     preds_decoded_text = tokenizer.batch_decode(
         preds_token_GSM8K, skip_special_tokens=True)
@@ -197,7 +204,11 @@ def main():
 
     # MBXP metric
     from evaluate_mbxp import evaluate_mbxp
-    result['mbxp'] = evaluate_mbxp(results_MBXP, args.n_workers)
+
+    if results_MBXP:
+        result['mbxp'] = evaluate_mbxp(results_MBXP, args.n_workers)
+    else:
+        result['mbxp'] = 0
 
     result = {
         **result,


### PR DESCRIPTION
Currently the mixtral accuracy script fails if we are running only 10 samples. This PR fixes this and we can see outputs like below
```
Accuracy file: /home/arjun/CM/repos/local/cache/f88c69500c934b67/test_results/arjun_spr-reference-cpu-pytorch-v2.2.1-default_config/mixtral-8x7b/offline/accuracy/accuracy.txt


Results

{'gsm8k': 70.0, 'mbxp': 0, 'gen_len': 0.0, 'gen_num': 10, 'gen_tok_len': 3174, 'tokens_per_sample': 317.4}

```