### PR TITLE
Update build_wheels.yml | Recommendation from MLCommons Admins

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -17,9 +17,10 @@ jobs:
     if: github.repository_owner == 'mlcommons'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       # Check if VERSION.txt file has changed in this push
       - name: Check if VERSION.txt file has changed


### PR DESCRIPTION
Use `ssh_key` instead of `token` in Github action.