### PR TITLE
Update artifact actions from v3 to v4 in build_wheels.yml

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -89,7 +89,7 @@ jobs:
 
        # Save wheels as artifacts
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
           path: wheels
@@ -106,19 +106,19 @@ jobs:
 
       # Download the built wheels from ubuntu
       - name: Download Ubuntu wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-ubuntu-latest
           path: wheels
       # Download the built wheels from macOS
       - name: Download macOS wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-macos-latest
           path: wheels
       # Download the built wheels from Windows
       - name: Download Windows wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-windows-latest
           path: wheels


### PR DESCRIPTION
GitHub recently notified us of the following:

> Artifact actions v3 will be deprecated by December 5, 2024... After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.
> 
> To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
> November 14, 12pm - 1pm EST
> November 21, 9am - 5pm EST
> 
> What you need to do
> Update workflows to begin using v4 of the artifact actions as soon as possible. While v4 improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://app.github.media/e/er?s=88570519&lid=6646&elqTrackId=d75d31293f0e47148c8f2a339957fcaf&elq=1beabda045604135a91423cb2bd2201f&elqaid=4245&elqat=1&elqak=8AF52EF15428B1DCF971E377BBEBF230341AA2716BED3091250A1BE093EDFE1D519F) from previous versions that may require updates to your workflows. Please see [the documentation](https://app.github.media/e/er?s=88570519&lid=6645&elqTrackId=53ce96ddadbb4fe1951a5a31db6a10b3&elq=1beabda045604135a91423cb2bd2201f&elqaid=4245&elqat=1&elqak=8AF5B7CF2FDD10084FA269DD666DEC9DD40FA2716BED3091250A1BE093EDFE1D519F) in the project repositories for guidance on how to migrate your workflows.

This PR updates actions/upload-artifact from v3 to v4. However, as noted above, there are some breaking changes in v4, so make sure the workflow will function as intended before merging this PR.