### PR TITLE
Implement KSM to pull a PAT for commits in format.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: "Code formatting"
 on:
   push:
     branches:
-    - "**"
+      - "**"
 
 env:
   python_version: "3.9"
@@ -12,16 +12,25 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Retrieve secrets from Keeper
+        id: ksecrets
+        uses: Keeper-Security/ksm-action@master
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+          secrets: |-
+            v2h4jKiZlJywDSoKzRMnRw/field/Access Token > env:PAT  # Fetch PAT and store in environment variable
+
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
       - name: Set up Python ${{ env.python_version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.python_version }}
 
-      - name: Format modified python files
+      - name: Format modified Python files
         env:
           filter: ${{ github.event.before }}
         run: |
@@ -49,6 +58,8 @@ jobs:
           done
 
       - name: Commit and push changes
+        env:
+          PAT: ${{ env.PAT }}  # Use PAT fetched from Keeper
         run: |
           HAS_CHANGES=$(git diff --staged --name-only)
           if [ ${#HAS_CHANGES} -gt 0 ]; then
@@ -56,5 +67,6 @@ jobs:
             git config --global user.email "mlcommons-bot@users.noreply.github.com"
             # Commit changes
             git commit -m '[Automated Commit] Format Codebase'
-            git push
-          fi 
+            # Use the PAT to push changes
+            git push https://x-access-token:${PAT}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}
+          fi


### PR DESCRIPTION
This PR updates the format.yml workflow to use a PAT to make automated commits rather than a SSH key. The SSH key method is specifically designed for making commits that bypass branch protections. The format.yml workflow does not need to bypass branch protections and instead needs a PAT to address the fact that the implicitly invoked `GITHUB_TOKEN` [will not trigger other workflow runs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), namely the CLA-bot, as seen in [this open PR](https://github.com/mlcommons/inference/pull/1491).

The modified version of format.yml in this PR uses [Keeper Secrets Manager](https://docs.keeper.io/en/secrets-manager/secrets-manager/integrations/github-actions) (KSM) to pull the `mlcommons-bot` PAT from Keeper. Our Keeper infrastructure handles the centralized management of keys, including automatic re-rolling of keys on demand and at regular intervals.