### PR TITLE
Update format.yml to us GITHUB_TOKEN & GitHub Actions bot

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,15 +11,9 @@ env:
 jobs:
   format-code:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Retrieve secrets from Keeper
-        id: ksecrets
-        uses: Keeper-Security/ksm-action@master
-        with:
-          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
-          secrets: |-
-            v2h4jKiZlJywDSoKzRMnRw/field/Access Token > env:PAT  # Fetch PAT and store in environment variable
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -58,15 +52,13 @@ jobs:
           done
 
       - name: Commit and push changes
-        env:
-          PAT: ${{ env.PAT }}  # Use PAT fetched from Keeper
         run: |
           HAS_CHANGES=$(git diff --staged --name-only)
           if [ ${#HAS_CHANGES} -gt 0 ]; then
-            git config --global user.name mlcommons-bot
-            git config --global user.email "mlcommons-bot@users.noreply.github.com"
+            git config --global user.name github-actions[bot]
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
             # Commit changes
             git commit -m '[Automated Commit] Format Codebase'
-            # Use the PAT to push changes
-            git push https://x-access-token:${PAT}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}
+            # Use the GITHUB_TOKEN to push changes
+            git push
           fi


### PR DESCRIPTION
This PR switches the format.yml workflow to use the built-in GITHUB_TOKEN and the corresponding GitHub Actions bot GitHub account to make commits rather than a PAT that is not accessible in forked repo branches attempting to merge into origin.