### PR TITLE
Add device map - pointpainting automotive

### DIFF
--- a/.github/workflows/test-resnet50.yml
+++ b/.github/workflows/test-resnet50.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: [ "3.9" ]
         backend: [ "onnxruntime", "tf" ]
         loadgen-flag: [ "", "--adr.loadgen.tags=_from-pip --pip_loadgen=yes" ]
-
+ 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/automotive/3d-object-detection/backend_deploy.py
+++ b/automotive/3d-object-detection/backend_deploy.py
@@ -71,7 +71,9 @@ class BackendDeploy(backend.Backend):
             painted=True).to(
             device=device)
         model.eval()
-        checkpoint = torch.load(self.lidar_detector_path, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))
+        checkpoint = torch.load(
+            self.lidar_detector_path, map_location=torch.device(
+                'cuda' if torch.cuda.is_available() else 'cpu'))
         model.load_state_dict(checkpoint["model_state_dict"])
         self.lidar_detector = model
 

--- a/automotive/3d-object-detection/backend_deploy.py
+++ b/automotive/3d-object-detection/backend_deploy.py
@@ -71,7 +71,7 @@ class BackendDeploy(backend.Backend):
             painted=True).to(
             device=device)
         model.eval()
-        checkpoint = torch.load(self.lidar_detector_path)
+        checkpoint = torch.load(self.lidar_detector_path, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))
         model.load_state_dict(checkpoint["model_state_dict"])
         self.lidar_detector = model
 

--- a/automotive/3d-object-detection/model/painter.py
+++ b/automotive/3d-object-detection/model/painter.py
@@ -57,7 +57,7 @@ class Painter:
         else:
             model = network.modeling.__dict__['deeplabv3plus_resnet50'](
                 num_classes=19, output_stride=16)
-            checkpoint = torch.load(checkpoint_file)
+            checkpoint = torch.load(checkpoint_file, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))
             model.load_state_dict(checkpoint["model_state"])
             model.eval()
             device = torch.device(

--- a/automotive/3d-object-detection/model/painter.py
+++ b/automotive/3d-object-detection/model/painter.py
@@ -57,7 +57,9 @@ class Painter:
         else:
             model = network.modeling.__dict__['deeplabv3plus_resnet50'](
                 num_classes=19, output_stride=16)
-            checkpoint = torch.load(checkpoint_file, map_location=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))
+            checkpoint = torch.load(
+                checkpoint_file, map_location=torch.device(
+                    'cuda' if torch.cuda.is_available() else 'cpu'))
             model.load_state_dict(checkpoint["model_state"])
             model.eval()
             device = torch.device(

--- a/automotive/3d-object-detection/tools/evaluate.py
+++ b/automotive/3d-object-detection/tools/evaluate.py
@@ -84,8 +84,8 @@ def do_eval(det_results, gt_results, CLASSES, cam_sync=False):
         det_bboxes3d = np.concatenate(
             [det_location, det_dimensions, det_rotation_y[:, None]], axis=-1)
         iou3d_v = iou3d_camera(
-            torch.from_numpy(gt_bboxes3d).cuda(),
-            torch.from_numpy(det_bboxes3d).cuda())
+            torch.from_numpy(gt_bboxes3d).to("cuda" if torch.cuda.is_available() else "cpu"),
+            torch.from_numpy(det_bboxes3d).to("cuda" if torch.cuda.is_available() else "cpu"))
         ious['bbox_3d'].append(iou3d_v.cpu().numpy())
 
     MIN_IOUS = {

--- a/automotive/3d-object-detection/tools/evaluate.py
+++ b/automotive/3d-object-detection/tools/evaluate.py
@@ -84,7 +84,8 @@ def do_eval(det_results, gt_results, CLASSES, cam_sync=False):
         det_bboxes3d = np.concatenate(
             [det_location, det_dimensions, det_rotation_y[:, None]], axis=-1)
         iou3d_v = iou3d_camera(
-            torch.from_numpy(gt_bboxes3d).to("cuda" if torch.cuda.is_available() else "cpu"),
+            torch.from_numpy(gt_bboxes3d).to(
+                "cuda" if torch.cuda.is_available() else "cpu"),
             torch.from_numpy(det_bboxes3d).to("cuda" if torch.cuda.is_available() else "cpu"))
         ious['bbox_3d'].append(iou3d_v.cpu().numpy())
 


### PR DESCRIPTION
This PR solves the following errors while running in `cpu-only` mode:

```
Traceback (most recent call last):
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/main.py", line 466, in <module>
    main()
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/main.py", line 327, in main
    model = backend.load()
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/backend_deploy.py", line 67, in load
    self.painter = Painter(painting_args)
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/model/painter.py", line 60, in _init_
    checkpoint = torch.load(checkpoint_file)
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 1026, in load
    return _load(opened_zipfile,
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 1438, in _load
    result = unpickler.load()
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 1408, in persistent_load
    typed_storage = load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 1382, in load_tensor
    wrap_storage=restore_location(storage, location),
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 391, in default_restore_location
    result = fn(storage, location)
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 266, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/serialization.py", line 250, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.loa
d with map_location=torch.device('cpu') to map your storages to the CPU
```

```
Traceback (most recent call last):
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/accuracy_waymo.py", line 129, in <module>
    main()
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/accuracy_waymo.py", line 113, in main
    map_stats = do_eval(
  File "/root/MLC/repos/local/cache/get-git-repo_76dad388/inference/automotive/3d-object-detection/tools/evaluate.py", line 87, in do_eval
    torch.from_numpy(gt_bboxes3d).cuda(),
  File "/root/venv/mlc/lib/python3.10/site-packages/torch/cuda/_init_.py", line 293, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
```