### PR TITLE
[405B] Set max_tokens to 2k

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,7 +3,7 @@ name: Build loadgen wheels and release them into PYPI
 on:
   release:
     types: [published]
-  
+
   push:
     branches:
       - master

--- a/language/llama3.1-405b/SUT_VLLM.py
+++ b/language/llama3.1-405b/SUT_VLLM.py
@@ -72,7 +72,7 @@ class SUT:
             "top_p": 1,
             "top_k": 1,
             "seed": 42,
-            "max_tokens": 20000,
+            "max_tokens": 2000,
             "min_tokens": 2
         }
         self.sampling_params = SamplingParams(**gen_kwargs)

--- a/language/mixtral-8x7b/SUT.py
+++ b/language/mixtral-8x7b/SUT.py
@@ -119,7 +119,6 @@ class FirstTokenStreamer(BaseStreamer):
             self.first_token.put((value, self.response_ids[0]))
 
             self.is_first_token = False
-        
 
         self.tokens_cache.append(value)
 
@@ -413,7 +412,7 @@ class SUTServer(SUT):
 
             batch_texts = [self.data_object.input_texts[qitem.index]]
             batch_ids = self.tokenizer.batch_encode_plus(
-                    batch_texts, return_tensors="pt", padding=True)
+                batch_texts, return_tensors="pt", padding=True)
             batch_ids = batch_ids.to(self.device)
             _, length = batch_ids.input_ids.shape
 
@@ -427,7 +426,6 @@ class SUTServer(SUT):
                 response_ids=[qitem.id],
             )
 
-            
             _ = self.model.generate(
                 **batch_ids,
                 num_return_sequences=1,


### PR DESCRIPTION
Maximum reference output token across samples is under 2k, so we have to limit generation outputs as well.