### PR TITLE
Update loadgen package name in classification_and_detection setup

### DIFF
--- a/vision/classification_and_detection/setup.py
+++ b/vision/classification_and_detection/setup.py
@@ -100,7 +100,7 @@ setup(
         "pybind11",
         "Cython",
         "pycocotools",
-        "mlperf_loadgen",
+        "mlcommons_loadgen",
         "opencv-python-headless",
     ],
 )


### PR DESCRIPTION
Hi! According to #1864, the loadgen pypi package is used in `vision/classification_and_detection`. This causes the `setup.py` script to fail when following the instructions in the README.md. 

I changed the name to `mlcommons_loadgen` as suggested and this seemed to work. I would appreciate a proper verification from @pgmpablo157321 or another maintainer of the benchmark (Feel free to tag them if you know who they are): does this look right?

Thank you for your time!