### PR TITLE
Add exception for github-actions[bot] to cla.yml

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
           path-to-signatures: 'cla-bot/v1/cla.json'
           # branch should not be protected
           branch: 'main'
-          allowlist: user1,bot*
+          allowlist: user1,bot*,github-actions[bot]
           remote-organization-name: mlcommons
           remote-repository-name: systems
           


### PR DESCRIPTION
This PR adds the GitHub Actions bot to the CLA bot allowlist so that commits made by the bot are not blocked by the CLA bot.