### PR TITLE
Fix for Recognizing --threads Option in Benchmarking

### DIFF
--- a/vision/classification_and_detection/python/backend_onnxruntime.py
+++ b/vision/classification_and_detection/python/backend_onnxruntime.py
@@ -26,7 +26,14 @@ class BackendOnnxruntime(backend.Backend):
 
     def load(self, model_path, inputs=None, outputs=None):
         """Load model and find input/outputs from the model file."""
+        print("************************************************************")
+        print(">>> Value of num_threads: ", num_threads)
+        print("************************************************************")
+        os.environ["OMP_NUM_THREADS"] = str(num_threads)
+        os.environ["OPENBLAS_NUM_THREADS"] = str(num_threads)
+        os.environ["MKL_NUM_THREADS"] = str(num_threads)
         opt = rt.SessionOptions()
+        opt.intra_op_num_threads = int(num_threads)
 
         # By default all optimizations are enabled
         # https://onnxruntime.ai/docs/performance/graph-optimizations.html

--- a/vision/classification_and_detection/python/main.py
+++ b/vision/classification_and_detection/python/main.py
@@ -646,7 +646,9 @@ def main():
         model = backend.load(
             args.model,
             inputs=args.inputs,
-            outputs=args.outputs)
+            # outputs=args.output,
+            num_threads=args.threads
+            )
     final_results = {
         "runtime": model.name(),
         "version": model.version(),


### PR DESCRIPTION
In reference to [this](https://github.com/mlcommons/mlperf-automations/issues/293) issue

- Updated backend_onnxruntime.py to set threading options based on the value of --threads, and also set environment variables to align lower-level library threading for consistency
- Modified `main.py` to correctly propagate the `--threads` argument to the backend loader, which was previously missing.
- Commented out `outputs` parameter as `args.output` is a string, not a list, and during execution the script was failing as Onnx Runtime was expecting a list of output tensor names.

Test Logs: 

[mlc log thread command run.txt](https://github.com/user-attachments/files/19500151/mlc.log.thread.command.run.txt)

System stats during the execution of the script with --threads=2

![Screenshot 2025-03-28 061424](https://github.com/user-attachments/assets/0b3c888e-0368-4e6f-ab56-996ea0625dac)

