### PR TITLE
Fix misleading CUDA device specification by replacing 'cuda:0' with 'cuda'

### DIFF
--- a/automotive/3d-object-detection/backend_deploy.py
+++ b/automotive/3d-object-detection/backend_deploy.py
@@ -54,7 +54,7 @@ class BackendDeploy(backend.Backend):
         return "python-SUT"
 
     def load(self):
-        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         PaintArgs = namedtuple(
             'PaintArgs', [
                 'training_path', 'model_path', 'cam_sync'])
@@ -84,7 +84,7 @@ class BackendDeploy(backend.Backend):
         ], [], [], [], [], [], []
         with torch.inference_mode():
             device = torch.device(
-                "cuda:0" if torch.cuda.is_available() else "cpu")
+                "cuda" if torch.cuda.is_available() else "cpu")
             model_input = inputs[0]
             batched_pts = model_input['pts']
             scores_from_cam = []

--- a/language/bert/pytorch_SUT.py
+++ b/language/bert/pytorch_SUT.py
@@ -61,7 +61,7 @@ class BERT_PyTorch_SUT:
 
         self.network = args.network
         self.dev = (
-            torch.device("cuda:0") if torch.cuda.is_available(
+            torch.device("cuda") if torch.cuda.is_available(
             ) else torch.device("cpu")
         )
         self.version = transformers.__version__

--- a/language/gpt-j/backend_PyTorch.py
+++ b/language/gpt-j/backend_PyTorch.py
@@ -81,7 +81,7 @@ class SUT_base:
         if self.use_gpu:
             print(f"Casting models to GPU...")
             assert torch.cuda.is_available(), "torch gpu is not available, exiting..."
-            self.device = torch.device("cuda:0")
+            self.device = torch.device("cuda")
             self.model.to(self.device)
 
         self.model.eval()

--- a/language/llama2-70b/README.md
+++ b/language/llama2-70b/README.md
@@ -152,7 +152,7 @@ python3 -u main.py --scenario Offline \
         --dataset-path ${DATASET_PATH} \
         --output-log-dir offline-logs \
         --dtype float32 \
-        --device cuda:0 2>&1 | tee offline_performance_log.log
+        --device cuda 2>&1 | tee offline_performance_log.log
 ```
 
 ### Server

--- a/language/llama2-70b/main.py
+++ b/language/llama2-70b/main.py
@@ -63,7 +63,7 @@ def get_args():
     parser.add_argument(
         "--device",
         type=str,
-        choices=["cpu", "cuda:0"],
+        choices=["cpu", "cuda"],
         default="cpu",
         help="device to use",
     )

--- a/language/llama2-70b/run_accuracy.sh
+++ b/language/llama2-70b/run_accuracy.sh
@@ -12,7 +12,7 @@ python3 -u main.py --scenario Offline \
         --dataset-path ${DATASET_PATH} \
         --output-log-dir offline_accuracy_loadgen_logs \
         --dtype float32 \
-        --device cuda:0 2>&1 | tee offline_accuracy_log.log
+        --device cuda 2>&1 | tee offline_accuracy_log.log
 
 python3 evaluate-accuracy.py --checkpoint-path ${CHECKPOINT_PATH} \
         --mlperf-accuracy-file offline_accuracy_loadgen_logs/mlperf_log_accuracy.json \

--- a/language/mixtral-8x7b/README.md
+++ b/language/mixtral-8x7b/README.md
@@ -148,7 +148,7 @@ python3 -u main.py --scenario Offline \
         --dataset-path ${DATASET_PATH} \
         --output-log-dir offline-logs \
         --dtype float32 \
-        --device cuda:0 2>&1 | tee offline_performance_log.log
+        --device cuda 2>&1 | tee offline_performance_log.log
 ```
 
 ### Server

--- a/language/mixtral-8x7b/main.py
+++ b/language/mixtral-8x7b/main.py
@@ -46,7 +46,7 @@ def get_args():
     parser.add_argument(
         "--device",
         type=str,
-        choices=["cpu", "cuda:0"],
+        choices=["cpu", "cuda"],
         default="cpu",
         help="device to use",
     )

--- a/language/mixtral-8x7b/run_accuracy.sh
+++ b/language/mixtral-8x7b/run_accuracy.sh
@@ -11,7 +11,7 @@ python3 -u main.py --scenario Offline \
         --dataset-path ${DATASET_PATH} \
         --output-log-dir offline_accuracy_loadgen_logs \
         --dtype float32 \
-        --device cuda:0 2>&1 | tee offline_accuracy_log.log
+        --device cuda 2>&1 | tee offline_accuracy_log.log
 
 python3 evaluate-accuracy.py --checkpoint-path ${CHECKPOINT_PATH} \
         --mlperf-accuracy-file offline_accuracy_loadgen_logs/mlperf_log_accuracy.json \

--- a/recommendation/dlrm_v2/pytorch/python/backend_pytorch_native.py
+++ b/recommendation/dlrm_v2/pytorch/python/backend_pytorch_native.py
@@ -65,7 +65,7 @@ class BackendPytorchNative(backend.Backend):
         os.environ["MASTER_ADDR"] = "localhost"
         os.environ["MASTER_PORT"] = "29500"
         if self.use_gpu:
-            self.device: torch.device = torch.device(f"cuda:0")
+            self.device: torch.device = torch.device(f"cuda")
             self.dist_backend = "nccl"
             # torch.cuda.set_device(self.device)
         else:

--- a/retired_benchmarks/recommendation/dlrm/pytorch/python/backend_pytorch_native.py
+++ b/retired_benchmarks/recommendation/dlrm/pytorch/python/backend_pytorch_native.py
@@ -22,7 +22,7 @@ class BackendPytorchNative(backend.Backend):
         self.ln_top = ln_top
 
         self.use_gpu = use_gpu and torch.cuda.is_available()
-        self.device = "cuda:0" if self.use_gpu else "cpu"
+        self.device = "cuda" if self.use_gpu else "cpu"
 
         ngpus = torch.cuda.device_count() if self.use_gpu else -1
         self.ndevices = min(ngpus, mini_batch_size, ln_emb.size)

--- a/retired_benchmarks/speech_recognition/rnnt/pytorch/decoders.py
+++ b/retired_benchmarks/speech_recognition/rnnt/pytorch/decoders.py
@@ -43,7 +43,7 @@ class ScriptGreedyDecoder(torch.nn.Module):
         self._blank_id = blank_index
         self._SOS = -1
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")

--- a/retired_benchmarks/speech_recognition/rnnt/pytorch/model_separable_rnnt.py
+++ b/retired_benchmarks/speech_recognition/rnnt/pytorch/model_separable_rnnt.py
@@ -70,7 +70,7 @@ class Encoder(torch.nn.Module):
     ):
         super().__init__()
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")
@@ -122,7 +122,7 @@ class Prediction(torch.nn.Module):
     ):
         super().__init__()
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")
@@ -195,7 +195,7 @@ class Joint(torch.nn.Module):
     ):
         super().__init__()
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")

--- a/retired_benchmarks/speech_recognition/rnnt/pytorch/rnn.py
+++ b/retired_benchmarks/speech_recognition/rnnt/pytorch/rnn.py
@@ -65,7 +65,7 @@ class LstmDrop(torch.nn.Module):
         """
         super(LstmDrop, self).__init__()
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")
@@ -111,7 +111,7 @@ class StackTime(torch.nn.Module):
         super().__init__()
         self.factor = int(factor)
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")

--- a/retired_benchmarks/speech_recognition/rnnt/pytorch_SUT.py
+++ b/retired_benchmarks/speech_recognition/rnnt/pytorch_SUT.py
@@ -55,7 +55,7 @@ class PytorchSUT:
         featurizer_config = config["input_eval"]
 
         self.dev = (
-            torch.device("cuda:0")
+            torch.device("cuda")
             if torch.cuda.is_available()
             and os.environ.get("USE_GPU", "").lower() not in ["no", "false"]
             else torch.device("cpu")

--- a/retired_benchmarks/vision/classification_and_detection/python/backend_pytorch.py
+++ b/retired_benchmarks/vision/classification_and_detection/python/backend_pytorch.py
@@ -53,7 +53,7 @@ class BackendPytorch(backend.Backend):
                 self.outputs.append(i.name)
 
         # prepare the backend
-        device = "CUDA:0" if torch.cuda.is_available() else "CPU"
+        device = "cuda" if torch.cuda.is_available() else "CPU"
         self.sess = caffe2.python.onnx.backend.prepare(self.model, device)
         return self
 

--- a/retired_benchmarks/vision/classification_and_detection/python/backend_pytorch_native.py
+++ b/retired_benchmarks/vision/classification_and_detection/python/backend_pytorch_native.py
@@ -12,7 +12,7 @@ class BackendPytorchNative(backend.Backend):
         super(BackendPytorchNative, self).__init__()
         self.sess = None
         self.model = None
-        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
     def version(self):
         return torch.__version__

--- a/retired_benchmarks/vision/medical_imaging/3d-unet-brats19/pytorch_SUT.py
+++ b/retired_benchmarks/vision/medical_imaging/3d-unet-brats19/pytorch_SUT.py
@@ -55,7 +55,7 @@ class _3DUNET_PyTorch_SUT:
         )
         self.trainer.load_checkpoint_ram(params[0], False)
         self.device = torch.device(
-            "cuda:0" if torch.cuda.is_available() else "cpu")
+            "cuda" if torch.cuda.is_available() else "cpu")
 
         print("Constructing SUT...")
         self.sut = lg.ConstructSUT(self.issue_queries, self.flush_queries)

--- a/retired_benchmarks/vision/medical_imaging/3d-unet-brats19/unet_pytorch_to_onnx.py
+++ b/retired_benchmarks/vision/medical_imaging/3d-unet-brats19/unet_pytorch_to_onnx.py
@@ -77,7 +77,7 @@ def main():
     width = 224
     depth = 160
     channels = 4
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     dummy_input = torch.rand(
         [1, channels, height, width, depth]).float().to(device)
     torch.onnx.export(

--- a/vision/classification_and_detection/python/backend_pytorch.py
+++ b/vision/classification_and_detection/python/backend_pytorch.py
@@ -53,7 +53,7 @@ class BackendPytorch(backend.Backend):
                 self.outputs.append(i.name)
 
         # prepare the backend
-        device = "CUDA:0" if torch.cuda.is_available() else "CPU"
+        device = "cuda" if torch.cuda.is_available() else "CPU"
         self.sess = caffe2.python.onnx.backend.prepare(self.model, device)
         return self
 

--- a/vision/classification_and_detection/python/backend_pytorch_native.py
+++ b/vision/classification_and_detection/python/backend_pytorch_native.py
@@ -13,7 +13,7 @@ class BackendPytorchNative(backend.Backend):
         super(BackendPytorchNative, self).__init__()
         self.sess = None
         self.model = None
-        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
     def version(self):
         return torch.__version__

--- a/vision/medical_imaging/3d-unet-kits19/pytorch_SUT.py
+++ b/vision/medical_imaging/3d-unet-kits19/pytorch_SUT.py
@@ -71,7 +71,7 @@ class _3DUNET_PyTorch_SUT(BASE_3DUNET_SUT):
             model_path
         )
         self.device = torch.device(
-            "cuda:0" if torch.cuda.is_available() else "cpu")
+            "cuda" if torch.cuda.is_available() else "cpu")
         self.model = torch.jit.load(model_path, map_location=self.device)
         self.model.eval()
 

--- a/vision/medical_imaging/3d-unet-kits19/pytorch_checkpoint_SUT.py
+++ b/vision/medical_imaging/3d-unet-kits19/pytorch_checkpoint_SUT.py
@@ -302,7 +302,7 @@ class _3DUNET_PyTorch_CHECKPOINT_SUT(BASE_3DUNET_SUT):
             model_path
         )
         self.device = torch.device(
-            "cuda:0" if torch.cuda.is_available() else "cpu")
+            "cuda" if torch.cuda.is_available() else "cpu")
         self.model = Unet3D()
         self.model.to(self.device)
         checkpoint = torch.load(model_path, map_location=self.device)

--- a/vision/medical_imaging/3d-unet-kits19/unet_pytorch_to_onnx.py
+++ b/vision/medical_imaging/3d-unet-kits19/unet_pytorch_to_onnx.py
@@ -96,7 +96,7 @@ def main():
     assert Path(model_path).is_file(), "Cannot find the model file {:}!".format(
         model_path
     )
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     model = torch.jit.load(model_path, map_location=device)
     model.eval()


### PR DESCRIPTION
This change updates the CUDA device specification from cuda:0 to cuda to prevent confusion. Specifying cuda:0 can be misleading as it utilises all available GPUs, not just GPU 0. By using CUDA, the behaviour aligns with user expectations and improves clarity in device selection.

This issue was also discussed in #2165, where it was noted that the cuda:0 label could cause misunderstanding in multi-GPU environments. This fix ensures consistency and avoids potential misinterpretation.