### PR TITLE
Fix typo in text_to_image/README.md

### DIFF
--- a/text_to_image/README.md
+++ b/text_to_image/README.md
@@ -58,7 +58,7 @@ The following MLCommons MLC commands can be used to programmatically download th
 mlcr get,ml-model,sdxl,_fp16,_rclone --outdirname=$MODEL_PATH
 ```
 ```
-mlcr get,ml-model,sdxl,_fp32,_rclone --outdirname-$MODEL_PATH
+mlcr get,ml-model,sdxl,_fp32,_rclone --outdirname=$MODEL_PATH
 ```
 #### Manual method
 


### PR DESCRIPTION
I believe that `--outdirname=` was mistakenly written as `--outdirname-`.