### PR TITLE
Partial fix for compliance TEST01 update

### DIFF
--- a/compliance/nvidia/TEST01/verify_performance.py
+++ b/compliance/nvidia/TEST01/verify_performance.py
@@ -41,10 +41,10 @@ RESULT_FIELD = {
 
 def parse_result_log(file_path):
     score, target_latency = 0, None
-    score = float(mlperf_log[RESULT_FIELD[scenario]])
 
     mlperf_log = MLPerfLog(file_path)
     scenario = mlperf_log["effective_scenario"]
+    score = float(mlperf_log[RESULT_FIELD[scenario]])
 
     if not (
         "result_validity" in mlperf_log.get_keys()

--- a/compliance/nvidia/TEST01/verify_performance.py
+++ b/compliance/nvidia/TEST01/verify_performance.py
@@ -39,7 +39,7 @@ RESULT_FIELD = {
 }
 
 
-def result_log(file_path):
+def parse_result_log(file_path):
     score, target_latency = 0, None
     score = float(mlperf_log[RESULT_FIELD[scenario]])
 


### PR DESCRIPTION
This PR addresses some straight-forward issues with the latest merged PR for the compliance TEST01 implementation.  

HOWEVER the dependency on MLPerfLog object remains broken as the dict lookups consistently return 'None' type objects rather than the intended log values (see log_parser.py).  Please address this with high priority, as the inability to run compliance TEST01 is holding back several customer releases.  Thank you. @pgmpablo157321 