### PR TITLE
[Whisper] accuracy threshold 

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -498,7 +498,7 @@ MODEL_CONFIG = {
             "rgat": ("acc", 0.7286 * 0.99),
             "pointpainting": ("mAP", 0.5425 * 0.999),
             "deepseek-r1": ("exact_match", 0.99 * 81.6773, "TOKENS_PER_SAMPLE", 0.9 * 4043.449),
-            "whisper": ("WER", 2.0671 * 0.99),
+            "whisper": ("ACCURACY", (100.0-2.0671) * 0.99),
         },
         "accuracy-upper-limit": {
             "stable-diffusion-xl": (


### PR DESCRIPTION
https://github.com/mlcommons/inference/blob/master/tools/submission/submission_checker.py#L501
WER 2.0671*0.99 = 2.046429%, which is a stricter WER. 
Per discussion before,  accuracy*0.99 make more seance. 
accuracy = 1-wer 
We should use accuracy * 0.99 instead of WER*0.99. 

`"ACCURACY", (100.0-2.0671) * 0.99`