### PR TITLE
[Whisper] remove test01 in whisper

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -3287,6 +3287,7 @@ def check_compliance_dir(
         "mixtral-8x7b",
         "llama3.1-405b",
         "deepseek-r1",
+        "whisper",
     ]:
         test_list.remove("TEST01")
 


### PR DESCRIPTION
As described in https://github.com/mlcommons/inference/issues/2276, test01 is not discussed/promised in v5.1. 