### PR TITLE
Use sample latency as the metric for llama3.1_8b_edge SingleStream

### DIFF
--- a/tools/submission/submission_checker.py
+++ b/tools/submission/submission_checker.py
@@ -801,6 +801,7 @@ RESULT_FIELD_BENCHMARK_OVERWRITE = {
         },
         "llama3.1-8b-edge": {
             "Offline": "result_tokens_per_second",
+            "SingleStream": "result_90.00_percentile_latency_ns",
         },
         "mixtral-8x7b": {
             "Offline": "result_tokens_per_second",


### PR DESCRIPTION
@hanyunfan @arjunsuresh for visibility