### PR TITLE
Fix minor typos in reference_mlperf_perf.sh and reference_mlperf_accuracy.sh 

### DIFF
--- a/speech2text/reference_mlperf_accuracy.sh
+++ b/speech2text/reference_mlperf_accuracy.sh
@@ -46,6 +46,7 @@ python reference_mlperf.py \
     --manifest ${MANIFEST_FILE} \
     --scenario ${SCENARIO} \
     --log_dir ${RUN_LOGS} \
-    --num_workers ${NUM_INSTS}
+    --num_workers ${NUM_INSTS} \
+    "--accuracy"
 
 echo "Time Stop: $(date +%s)"

--- a/speech2text/reference_mlperf_perf.sh
+++ b/speech2text/reference_mlperf_perf.sh
@@ -46,7 +46,6 @@ python reference_mlperf.py \
     --manifest ${MANIFEST_FILE} \
     --scenario ${SCENARIO} \
     --log_dir ${RUN_LOGS} \
-    --num_workers ${NUM_INSTS} \
-    "--accuracy"
+    --num_workers ${NUM_INSTS} 
 
 echo "Time Stop: $(date +%s)"


### PR DESCRIPTION
The `reference_mlperf_perf.sh` script ran with the `--accuracy` option, which resulted in an accuracy validation run instead of the intended performance-only test.