### PR TITLE
Update minimum disk space required for PointPainting

### DIFF
--- a/main.py
+++ b/main.py
@@ -486,7 +486,7 @@ def define_env(env):
             # disk space
             ds = {
                 "dlrm": "500GB",
-                "pointpainting": "500GB",
+                "pointpainting": "950GB",
                 "llama2-70b": "900GB",
                 "llama3_1-405b": "2.3TB",
                 "mixtral": "100GB",


### PR DESCRIPTION
The dataset download size is around 450Gb, but the final size after extraction is around 850 Gb