### PR TITLE
[VLM] Clarify in the README that prefix caching is not allowed per MLPerf Inference rules.

### DIFF
--- a/multimodal/qwen3-vl/scripts/slurm/benchmark.sh
+++ b/multimodal/qwen3-vl/scripts/slurm/benchmark.sh
@@ -26,4 +26,5 @@ srun \
         --vllm.cli=--max-model-len=32768 \
         --vllm.cli=--limit-mm-per-prompt.video=0 \
         --vllm.cli=--tensor-parallel-size="${TENSOR_PARALLEL_SIZE}" \
+        --vllm.cli=--no-enable-prefix-caching \
         --settings.logging.log_output.outdir="${OUTPUT_CONTAINER_DIR}"/"${SLURM_JOB_ID}" 


### PR DESCRIPTION
As the title suggest, per [MLPerf Inference rules (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#94-llm-benchmarks), cross-query prefix caching is not allowed. This PR updates the README and the example scripts as such.