### PR TITLE
Moving sys import

### DIFF
--- a/tools/submission/submission_checker/main.py
+++ b/tools/submission/submission_checker/main.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 import os
+import sys
 
 if __name__ == "__main__" and __package__ is None:
-    import sys
     sys.path.append(os.path.dirname(os.path.dirname(__file__)))
     __package__ = "submission_checker"
 


### PR DESCRIPTION
Getting 'missing  sys package' error when running with README instructions.  Moving sys package import here resolves.