### PR TITLE
Update run_mlperf.py | We should not call FromConfig using audit.conf…

### DIFF
--- a/text_to_video/wan-2.2-t2v-a14b/run_mlperf.py
+++ b/text_to_video/wan-2.2-t2v-a14b/run_mlperf.py
@@ -270,8 +270,7 @@ def run_mlperf(args, config):
         settings.FromConfig(user_conf, "wan-2.2-t2v-a14b", args.scenario)
 
         audit_config = os.path.abspath(args.audit_conf)
-        if os.path.exists(audit_config):
-            settings.FromConfig(audit_config, "wan-2.2-t2v-a14b", args.scenario)
+        
         settings.scenario = SCENARIO_MAP[args.scenario]
 
         settings.mode = lg.TestMode.PerformanceOnly


### PR DESCRIPTION
… file

FromConfig call must be done only for user.conf file. AuditFile config override is done automatically by loadgen. The current code will fail the submission checker