### PR TITLE
Fixes for auto-close-old-issues-prs.yml

### DIFF
--- a/.github/workflows/auto-close-old-issues-prs.yml
+++ b/.github/workflows/auto-close-old-issues-prs.yml
@@ -1,33 +1,32 @@
 name: Close old issues and PRs older than 2 years
+
 on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
- 
+
 permissions:
   issues: write
   pull-requests: write
- 
+
 jobs:
   close-old:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:
-          start-date: created_at<=-730 days
-          days-before-issue-stale: -1
+          days-before-issue-stale: 730
           days-before-issue-close: 0
           close-issue-message: |
             🔒 This issue has been **automatically closed** because it has been open for more than 2 years with no activity.
             If this is still relevant, you may **reopen it or create a new one**.
           close-issue-reason: not_planned
- 
-          days-before-pr-stale: -1
+
+          days-before-pr-stale: 730
           days-before-pr-close: 0
           close-pr-message: |
             🔒 This pull request has been **automatically closed** because it has been open for more than 2 years with no activity.
             If you still want to proceed, you may **reopen this PR or open a new one**.
- 
-          exempt-issue-labels: pinned,security,long-term
-          exempt-pr-labels: pinned,security,wip
- 
+
+          exempt-issue-labels: pinned,security-fix,long-term
+          exempt-pr-labels: pinned,security-fix,wip


### PR DESCRIPTION
Hi @hanyunfan @pgmpablo157321  , this PR contains some fixes to previous [PR](https://github.com/mlcommons/inference/pull/2571)

I'm assuming that we are closing the PR's and issues based on the last updated date. If we are considering the created date, we have to set: `ignore-updates: true`

