### PR TITLE
Draft: CI/CD pipeline to test reference implementations

### DIFF
--- a/.github/workflows/functional-testing-of-reference-benchmarks.yml
+++ b/.github/workflows/functional-testing-of-reference-benchmarks.yml
@@ -1,0 +1,48 @@
+name: Trigger GPU Benchmark on PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      # Vision benchmarks
+      - 'vision/classification_and_detection/yolo/**'
+
+concurrency:
+  group: inference-gpu-benchmark-testing-pipeline
+  cancel-in-progress: false
+
+jobs:
+  capture_pr_info:
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.shas.outputs.base_sha }}
+      head_sha: ${{ steps.shas.outputs.head_sha }}
+      pr_number: ${{ steps.shas.outputs.pr_number }}
+    steps:
+      - name: Capture PR commit SHAs and PR number
+        id: shas
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # Pass FULL SHAs as outputs — trimming happens in private repo for display only
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
+          # Log short SHAs for readability
+          echo "Base SHA : ${BASE_SHA:0:7}"
+          echo "Head SHA : ${HEAD_SHA:0:7}"
+          echo "PR Number: ${{ github.event.pull_request.number }}"
+
+  approval_gate:
+    needs: capture_pr_info
+    runs-on: ubuntu-latest
+    environment: self-hosted-runner-benchmark-approval
+    steps:
+      - name: Approved
+        run: |
+          echo "Approved by maintainer."
+          echo "PR     : #${{ needs.capture_pr_info.outputs.pr_number }}"
+          echo "Base   : ${{ needs.capture_pr_info.outputs.base_sha }}"
+          echo "Head   : ${{ needs.capture_pr_info.outputs.head_sha }}"


### PR DESCRIPTION
This PR introduces a  CI/CD pipeline to test reference implementations. It triggers on PRs raised against the inference repository. The goal is to automatically detect which benchmark is relevant based on the files changed, run it on our self-hosted MLC2 GPU server, and post the results back as a PR comment with an initial approval step.

<img width="559" height="463" alt="image" src="https://github.com/user-attachments/assets/75b24bd3-c3ed-4c4c-bb21-3f8977f4020a" />

When a PR is opened:

1. **Approval gate**: A maintainer reviews and approves the benchmark run via GitHub's environment protection UI. 
2. **GitHub App (hosted on MLC2)**: On approval, our GitHub App receives a workflow_run event and determines which repo the PR came from.
3. **Routing logic**:

**Inference repo**: Automatically detects which folder was modified (e.g. vision/classification_and_detection/yolo/) and dispatches the corresponding benchmark workflow. No extra input from the maintainer needed.
**Endpoints repo**: Routes based on PR labels (benchmark:llama3, benchmark:all, etc.) added by the maintainer before approval.

4. Benchmark runs on MLC2 via a self-hosted GitHub Actions runner in a private repo, keeping all infrastructure and credentials completely isolated from the public repo.
5. Results posted back as a comment on the originating PR.

**TBD in inference repo to change the draft state of the PR**

- [ ] GitHub App to be installed on mlcommons/inference
- [ ] GitHub Environment self-hosted-runner-benchmark-approval to be configured with required reviewers
- [ ] GitHub repo mapping updated for production repo names

**Note:**

Currently the worfklow supports yolo benchmark only. More to be added in time