### PR TITLE
Initial pre-commit for formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v2.0.4
+    hooks:
+      - id: autopep8
+        args: ['--in-place', '-a', '--max-line-length', '79']
+        exclude: 'tools/submission/power/power_checker\.py'
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.5
+    hooks:
+      - id: clang-format
+        args: ['--style=file']
+        types_or: [c, c++]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
As discussed in the WG Benchmark Infra meeting, here's the file needed for pre-commit to work seamlessly.

When you install their CLI and run "pre-commit install" at the root of the repo, it will auto-format everything that the CI job cares about, alongside running gitleaks checks.

See https://pre-commit.com/ for details on installation, but I like it.