### PR TITLE
[gpt-oss-120b] Fix TEST07/TEST09 compliance to issue each sample exactly once

### DIFF
--- a/compliance/TEST07/gpt-oss-120b/audit.config
+++ b/compliance/TEST07/gpt-oss-120b/audit.config
@@ -19,6 +19,10 @@
 *.*.min_query_count = 990
 *.*.min_duration = 0
 
+# Issue each loaded sample exactly once (no random-with-replacement repeats),
+# so all 990 compliance samples are covered.
+*.*.performance_issue_unique = 1
+
 # Turn off sample concatenation for accurate logging
 *.*.sample_concatenate_permutation = 0
 

--- a/compliance/TEST09/gpt-oss-120b/audit.config
+++ b/compliance/TEST09/gpt-oss-120b/audit.config
@@ -20,6 +20,10 @@
 *.*.min_query_count = 6396
 *.*.min_duration = 0
 
+# Issue each loaded sample exactly once (no random-with-replacement repeats),
+# so all 6396 dataset samples are covered.
+*.*.performance_issue_unique = 1
+
 # Turn off sample concatenation for accurate logging
 *.*.sample_concatenate_permutation = 0
 


### PR DESCRIPTION
## Problem

TEST07/TEST09 run in PerformanceOnly mode, where loadgen draws samples **randomly with replacement**. Setting `min_query_count` to the dataset size does not give full-dataset coverage.

Measured with TEST07's exact settings (Server scenario, 990-sample QSL, `min_query_count=990`, `min_duration=0`):

| | issued | unique | repeated | never issued |
|---|---|---|---|---|
| current audit.config | 990 | 619 | 264 | **371 (37%)** |
| with `performance_issue_unique=1` | 990 | 990 | 0 | 0 |

So TEST07 currently scores accuracy on a skewed ~62% subset of the GPQA compliance set, and TEST09's mean-OSL check over its 6396 samples is similarly skewed.

## Fix

Add `*.*.performance_issue_unique = 1` to both gpt-oss audit.configs. With this flag loadgen uses the same unique (shuffled, no-replacement) sample distribution as accuracy mode (`loadgen.cc`), issuing every loaded sample exactly once.

- Key is parseable from audit.config (ungated in `TestSettings::FromConfig`, `test_settings_internal.cc:775`).
- `performance_sample_count_override = 6396` for gpt-oss ≥ both dataset sizes (990 / 6396), so the full dataset is loaded and covered.
- Existing `min_query_count`/`min_duration` lines become redundant (flag overrides them) but are kept as documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)