### PR TITLE
[e2e-rag] Fix error when running retrieval with reranker

### DIFF
--- a/e2e-rag/evaluation.py
+++ b/e2e-rag/evaluation.py
@@ -1,4 +1,5 @@
 # Copyright 2025 The MLPerf Authors. All Rights Reserved.
+# Copyright 2026 Arm Ltd. and affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -135,9 +136,10 @@ def evaluate_retrieval_query(rag_db, query: str, expected_urls: List[str],
                        max_results=max_results, **strategy_params)
     retrieval_time = time.perf_counter() - retrieval_start
     
-    # Step 2: Apply reranking if enabled and reranker is available  
+    # Step 2: Apply reranking if enabled and reranker is available
     reranking_time = 0.0
-    if not no_rerank and hasattr(rag_db, '_reranker_model') and rag_db._reranker_model is not None:
+    has_reranker = getattr(rag_db, '_reranker_queue', None) is not None
+    if not no_rerank and has_reranker:
         # Safety check: If no results retrieved, skip reranking
         if not results:
             if verbose:
@@ -219,7 +221,7 @@ def evaluate_retrieval_query(rag_db, query: str, expected_urls: List[str],
             print("-" * 50)
 
         # Show reranked results if reranker is available and reranking was used
-        if not no_rerank and rag_db._reranker_model is not None:
+        if not no_rerank and has_reranker:
             print(f"\nReranking to top-{top_k_reranking}")
             print(f"Reranking results:")
 


### PR DESCRIPTION
When running this script with the reference implementation:

```
python3 single_shot_retrieval.py \
  --db vector_html_hnsw_len768_ov32_word.db \
  --query "2021 French Open Men's Singles winner" \
  --retriever_model intfloat_e5-base-v2/e5-base-v2 \
  --reranker_model colbert-ir_colbertv2.0/colbertv2.0 \
  --device auto \
  --top_k_retriever 50 \
  --top_k_reranking 10
```

It crashes since the `RagDB` class doesn't support a `_reranker_model` attribute. This was probably a typo and should've been `_reranker_model_name`.
I replaced this with `_reranker_queue` as it's a better proxy for determining if a re-ranker exists or not.