### PR TITLE
v6.1: Fix report generator

### DIFF
--- a/tools/submission/generate_final_report.py
+++ b/tools/submission/generate_final_report.py
@@ -168,6 +168,8 @@ def main():
             "wan-2.2-t2v-a14b",
             "qwen3-vl-235b-a22b",
             "gpt-oss-120b",
+            "e2e",
+            "e2e_vectorDB",
         ],
         ["SingleStream", "MultiStream", "Server", "Offline", "Interactive"],
         [
@@ -226,6 +228,55 @@ def main():
                 "stable-diffusion-xl": ["SingleStream", "Offline"],
                 "pointpainting": ["SingleStream"],
                 "whisper": ["Offline"]
+            },
+        }
+    elif args.version == "6.1":
+        filter_scenarios = {
+            "datacenter": {
+                "resnet": [],
+                "yolo-95": [],
+                "yolo-99": [],
+                "bert-99": [],
+                "bert-99.9": [],
+                "stable-diffusion-xl": [],
+                "llama3.1-8b-edge": [],
+                "dlrm-v3": ["Server", "Offline"],
+                "3d-unet-99": ["Offline"],
+                "3d-unet-99.9": ["Offline"],
+                "llama2-70b-99": ["Server", "Offline", "Interactive"],
+                "llama2-70b-99.9": ["Server", "Offline", "Interactive"],
+                "rgat": ["Offline"],
+                "llama3.1-8b": ["Server", "Offline", "Interactive"],
+                "deepseek-r1": ["Server", "Offline", "Interactive"],
+                "whisper": ["Offline"],
+                "gpt-oss-120b": ["Offline", "Interactive", "Server"],
+                "qwen3-vl-235b-a22b": ["Server", "Offline", "Interactive"],
+                "wan-2.2-t2v-a14b": ["Offline", "SingleStream"],
+                "e2e": ["Offline"],
+                "e2e_vectorDB": ["Offline"],
+            },
+            "edge": {
+                "resnet": ["SingleStream", "MultiStream", "Offline"],
+                "yolo-95": ["SingleStream", "MultiStream", "Offline"],
+                "yolo-99": ["SingleStream", "MultiStream", "Offline"],
+                "bert-99": ["SingleStream", "Offline"],
+                "bert-99.9": ["SingleStream", "Offline"],
+                "3d-unet-99": ["SingleStream", "Offline"],
+                "3d-unet-99.9": ["SingleStream", "Offline"],
+                "llama3.1-8b-edge": ["SingleStream", "Offline"],
+                "stable-diffusion-xl": ["SingleStream", "Offline"],
+                "whisper": ["Offline"],
+                "dlrm-v3": [],
+                "llama2-70b-99": [],
+                "llama2-70b-99.9": [],
+                "rgat": [],
+                "llama3.1-8b": [],
+                "deepseek-r1": [],
+                "gpt-oss-120b": [],
+                "qwen3-vl-235b-a22b": [],
+                "wan-2.2-t2v-a14b": [],
+                "e2e": [],
+                "e2e_vectorDB": [],
             },
         }
     elif args.version == "5.0":
@@ -352,7 +403,7 @@ def main():
 
     def FilterScenario(x, suite):
         return x.apply(
-            lambda y: y["Scenario"] in filter_scenarios[suite][y["Model"]], axis=1
+            lambda y: y["Scenario"] in filter_scenarios[suite].get(y["Model"], [y["Scenario"]]), axis=1
         )
 
     def MakeUniqueID(x):

--- a/tools/submission/submission_checker/constants.py
+++ b/tools/submission/submission_checker/constants.py
@@ -1573,6 +1573,7 @@ RESULT_FIELD_NEW = {
         "SingleStream": "early_stopping_latency_ss",
         "MultiStream": "early_stopping_latency_ms",
         "Server": "result_completed_samples_per_sec",
+        "Interactive": "result_completed_samples_per_sec",
     },
 }
 


### PR DESCRIPTION
- constants.py: add Interactive→result_completed_samples_per_sec to RESULT_FIELD_NEW["v6.1"] so performance_check.py doesn't KeyError on Loadgen++ (endpoints) Interactive submissions
- generate_final_report.py: split the shared v6.0/v6.1 filter_scenarios into separate per-version blocks; add e2e/e2e_vectorDB to the v6.1 datacenter block (Offline only) and to columns_order; remove v6.0-only models (mixtral-8x7b, llama3.1-405b, pointpainting) from the v6.1 block; add explicit edge exclusions for all v6.1 datacenter-only models to prevent datacenter-edge system results leaking into the edge worksheet