### PR TITLE
Add Online scenario support to submission checker for CloudEndpoint (gpt-oss-120b)

### DIFF
--- a/tools/submission/submission_checker/checks/performance_check.py
+++ b/tools/submission/submission_checker/checks/performance_check.py
@@ -477,7 +477,8 @@ class PerformanceCheck(BaseCheck):
             bool: True if inference is valid or not attempted, False otherwise.
         """
         if self.scenario.lower() != self.scenario_fixed.lower() and (
-                self.scenario.lower(), self.scenario_fixed.lower()) != ("server", "interactive"):
+                self.scenario.lower(), self.scenario_fixed.lower()) not in {
+                    ("server", "interactive"), ("server", "online")}:
             if "edge" not in self.system_json["system_type"].lower():
                 self.log.error(
                     "Result can not be inferred for %s suite for: %s. Scenario: %s, Scenario fixed: %s",
@@ -543,7 +544,8 @@ class PerformanceCheck(BaseCheck):
                 res /= S_TO_MS
 
         if self.scenario.lower() != self.scenario_fixed.lower() and (
-                self.scenario.lower(), self.scenario_fixed.lower()) != ("server", "interactive"):
+                self.scenario.lower(), self.scenario_fixed.lower()) not in {
+                    ("server", "interactive"), ("server", "online")}:
             res, is_valid = self.get_inferred_result(res)
         self.submission_logs.loader_data["performance_metric"] = res
         return is_valid

--- a/tools/submission/submission_checker/constants.py
+++ b/tools/submission/submission_checker/constants.py
@@ -44,7 +44,7 @@ MODEL_CONFIG = {
             "llama2-70b-99.9": ["Interactive", "Server"],
             "llama3.1-8b": ["Interactive", "Server"],
             "deepseek-r1": ["Interactive", "Server"],
-            "gpt-oss-120b": ["Interactive", "Server"],
+            "gpt-oss-120b": ["Online", "Server"],
             "qwen3-vl-235b-a22b": ["Interactive"],
         },
         "required-scenarios-edge": {
@@ -85,7 +85,7 @@ MODEL_CONFIG = {
             "llama2-70b-99.9": ["Interactive", "Server"],
             "llama3.1-8b": ["Interactive", "Server"],
             "deepseek-r1": ["Interactive", "Server"],
-            "gpt-oss-120b": ["Interactive", "Server"],
+            "gpt-oss-120b": ["Online", "Server"],
             "qwen3-vl-235b-a22b": ["Interactive", "Server"],
         },
         "accuracy-target": {
@@ -376,7 +376,7 @@ MODEL_CONFIG = {
             "llama3.1-405b": ["Interactive", "Server"],
             "llama3.1-8b": ["Interactive", "Server"],
             "deepseek-r1": ["Interactive", "Server"],
-            "gpt-oss-120b": ["Interactive", "Server"],
+            "gpt-oss-120b": ["Online", "Server"],
         },
         "required-scenarios-edge": {
             "resnet": ["SingleStream", "MultiStream", "Offline"],
@@ -1540,6 +1540,7 @@ SCENARIO_MAPPING = {
     "server": "Server",
     "offline": "Offline",
     "interactive": "Interactive",
+    "online": "Online",
 }
 
 RESULT_FIELD = {
@@ -1987,12 +1988,14 @@ UNIT_DICT = {
     "Offline": "Samples/s",
     "Server": "Queries/s",
     "Interactive": "Queries/s",
+    "Online": "Queries/s",
 
     "singlestream": "Latency (ms)",
     "multistream": "Latency (ms)",
     "offline": "Samples/s",
     "server": "Queries/s",
     "interactive": "Queries/s",
+    "online": "Queries/s",
 }
 
 
@@ -2002,12 +2005,14 @@ POWER_UNIT_DICT = {
     "Offline": "Watts",
     "Server": "Watts",
     "Interactive": "Watts",
+    "Online": "Watts",
 
     "singlestream": "millijoules",
     "multistream": "millijoules",
     "offline": "Watts",
     "server": "Watts",
     "interactive": "Watts",
+    "online": "Watts",
 }
 
 

--- a/tools/submission/submission_checker/results.py
+++ b/tools/submission/submission_checker/results.py
@@ -116,7 +116,8 @@ class ResultExporter:
         row["errors"] = 0
         row["version"] = self.config.version
         row["inferred"] = 1 if row["Scenario"] != submission_logs.performance_log["effective_scenario"] and (
-            submission_logs.performance_log["effective_scenario"], row["Scenario"]) != ("server", "interactive") else 0
+            submission_logs.performance_log["effective_scenario"], row["Scenario"]) not in {
+                ("server", "interactive"), ("server", "online")} else 0
         row["has_power"] = os.path.exists(
             submission_logs.loader_data["power_dir_path"])
         unit = SPECIAL_UNIT_DICT.get(

--- a/tools/submission/submission_checker/utils.py
+++ b/tools/submission/submission_checker/utils.py
@@ -302,7 +302,7 @@ def get_power_metric(config, scenario_fixed, log_path, is_valid, res):
     else:
         avg_power = sum(power_list) / len(power_list)
         power_duration = (power_end - power_begin).total_seconds()
-        if scenario_fixed in ["Offline", "Server", "Interactive"]:
+        if scenario_fixed in ["Offline", "Server", "Interactive", "Online"]:
             # In Offline and Server scenarios, the power metric is in W.
             power_metric = avg_power
             avg_power_efficiency = res / avg_power


### PR DESCRIPTION
## Summary

- **`constants.py`**: Replace `["Interactive", "Server"]` with `["Online", "Server"]` for `gpt-oss-120b` in all three `optional-scenarios` sections (datacenter, datacenter-edge, v6.1-specific). Add `"online"` / `"Online"` to `SCENARIO_MAPPING`, `UNIT_DICT`, and `POWER_UNIT_DICT`.
- **`performance_check.py`**: Extend the cross-scenario whitelist in `inferred_check()` and the performance-metric gate from `("server", "interactive")` only → also allows `("server", "online")`. This is needed because `gpt-oss-120b` submits under an `Online` directory but the loadgen effective scenario is mapped to `Server` internally.
- **`results.py`**: Extend the same whitelist in the `inferred` flag calculation.
- **`utils.py`**: Add `"Online"` to the power-metric Watts branch so power submissions under an `Online` directory are handled correctly.

## Context

CloudEndpoint submissions for `gpt-oss-120b` use `type: Online` in `config.yaml`. The checker reads this as `effective_scenario = Online` and maps it to `Server` for performance validation, but the directory is named `Online`. Every place in the checker that only knew about `("server", "interactive")` as a valid cross-scenario pair rejected these submissions. This PR makes `Online` a first-class scenario name throughout the checker.

## Test plan

- [x] Run `mlcr submission,inference,checker,mlc,_wg-inference --input=<submission_out> --submitter=CloudEndpoint --version=v6.1 --skip_compliance=yes` and confirm `SUMMARY: submission looks OK`
- [x] Confirm non-endpoints submissions (e.g. `SR680a_V3_B200SXMx8_TRT`) still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)