### PR TITLE
[Wan-2.2 T2V] Update sample IDs to use random_ids.txt

### DIFF
--- a/text_to_video/wan-2.2-t2v-a14b/data/samples_filename_ids.txt
+++ b/text_to_video/wan-2.2-t2v-a14b/data/samples_filename_ids.txt
@@ -3,8 +3,8 @@ A panda drinking coffee in a cafe in Paris, watercolor painting-0.mp4, 106.mp4
 The bund Shanghai, black and white-0.mp4, 84.mp4
 an elephant spraying itself with water using its trunk to cool down-0.mp4, 59.mp4
 a car turning a corner-0.mp4, 12.mp4
-a truck anchored in a tranquil bay-0.mp4, 31.mp4
-The bund Shanghai, in cyberpunk style-0.mp4, 86.mp4
-Gwen Stacy reading a book, in cyberpunk style-0.mp4, 122.mp4
-skyscraper-0.mp4, 223.mp4 
-a shark is swimming in the ocean, animated style-0.mp4, 96.mp4
+Gwen Stacy reading a book, animated style-0.mp4, 123.mp4
+a cat drinking water-0.mp4, 43.mp4
+an airplane landing smoothly on a runway-0.mp4, 22.mp4
+indoor swimming pool-0.mp4, 238.mp4
+a truck stuck in traffic during rush hour-0.mp4, 32.mp4


### PR DESCRIPTION
## Summary

- Replace the 5 random sample entries in `text_to_video/wan-2.2-t2v-a14b/data/samples_filename_ids.txt` with IDs from `tools/random_ids.txt` (123, 43, 22, 238, 32)
- Fixed IDs from `tools/fixed_idx.txt` (130, 106, 84, 59, 12) remain unchanged
- Prompts are looked up from `data/vbench_prompts.txt` using 0-based indexing

## Test plan

- [ ] Verify all 10 entries in `samples_filename_ids.txt` map to valid prompts in `vbench_prompts.txt`
- [ ] Confirm fixed IDs (lines 1-5) are unchanged from previous version
- [ ] Confirm random IDs (lines 6-10) match `tools/random_ids.txt`