### PR TITLE
Fix DeepSeek-R1 R2 downloader link to correct checkpoint

### DIFF
--- a/language/deepseek-r1/README.md
+++ b/language/deepseek-r1/README.md
@@ -27,7 +27,7 @@ Download the model using the MLCommons R2 Downloader:
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) \
-  https://inference.mlcommons-storage.org/metadata/deepseek-r1-0528.uri
+  https://inference.mlcommons-storage.org/metadata/deepseek-r1.uri
 ```
 
 To specify a custom download directory, use the `-d` flag:
@@ -35,7 +35,7 @@ To specify a custom download directory, use the `-d` flag:
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) \
   -d /path/to/download/directory \
-  https://inference.mlcommons-storage.org/metadata/deepseek-r1-0528.uri
+  https://inference.mlcommons-storage.org/metadata/deepseek-r1.uri
 ```
 
 ## Dataset Download


### PR DESCRIPTION
## Summary
- `language/deepseek-r1/README.md` pointed the R2 downloader at `deepseek-r1-0528.uri`, which resolves to **DeepSeek-R1-0528** instead of the intended **deepseek-ai/DeepSeek-R1** (revision `56d4cbbb4d29f4355bab4b9a39ccb717a14ad5ad`) named directly above it.
- The R2 bucket now hosts the correct checkpoint under `deepseek-r1.uri` (matching `r2-infra/inference/index.html`, which already links the correct URI). This PR brings the README in line.

## Verification
- Downloaded the model fresh via the R2 downloader using the corrected `deepseek-r1.uri` link (641GB, 174 files, downloader's own MD5 verification passed 174/174).
- Independently computed md5sums for the downloaded checkpoint and for a reference copy of `deepseek-ai/DeepSeek-R1` @ `56d4cbb` pulled from Hugging Face.
- Compared all 173 comparable files (weights, config, tokenizer, etc.) — **all filenames and md5sums matched exactly**, confirming the R2 bucket now serves the correct checkpoint.

## Test plan
- [x] Confirmed corrected URI downloads the intended checkpoint (md5sum match vs HF reference)
- [x] No other references to `deepseek-r1-0528.uri` remain in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)