### PR TITLE
Fix Loadgen Over the Network (LON) Demo

### DIFF
--- a/loadgen/demos/lon/sut_over_network_demo.py
+++ b/loadgen/demos/lon/sut_over_network_demo.py
@@ -81,8 +81,9 @@ def getname():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--node", type=str, default="")
     args = parser.parse_args()
     node = args.node
-    app.run(debug=False, port=args.port)
+    app.run(debug=False, host=args.host, port=args.port)


### PR DESCRIPTION
Add --host argument to sut_over_network_demo.py. By default, Flask will always bind the SUT to localhost (127.0.0.1) [1], which precludes this simple LON demo from being run over a network. This minor modification allows the SUT to be bound to any network interface [2].

[1]

[mkandes_test@exp-9-55 lon]$ python sut_over_network_demo.py --port 8000
 * Serving Flask app 'sut_over_network_demo'
 * Debug mode: off WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:8000 Press CTRL+C to quit

[2]

[mkandes_test@exp-1-27 lon]$ python sut_over_network_demo.py --host 10.21.1.27 --port 8000 --node n0
 * Serving Flask app 'sut_over_network_demo'
 * Debug mode: off WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://10.21.1.27:8000 Press CTRL+C to quit