### PR TITLE
Fix three defects in tools/submission/log_parser.py

### DIFF
--- a/tools/submission/log_parser.py
+++ b/tools/submission/log_parser.py
@@ -124,15 +124,16 @@ class MLPerfLog:
             else:
                 self.logger.warning(
                     "There are multiple messages with key {:} in the log. Emprically choosing the first one.".format(
-                        key
+                        message["key"]
                     )
                 )
+        return result
 
     def dump(self, output_path):
         """
         Dump the entire log as a json file.
         """
-        with open(log_path, "w") as f:
+        with open(output_path, "w") as f:
             json.dump(self.messages, f, indent=4)
 
     def num_messages(self):


### PR DESCRIPTION
## Summary

Three defects in `tools/submission/log_parser.py`, all in `MLPerfLog`:

**1. `get_dict()` never returns.** It builds `result` and falls off the end, so every caller gets `None`:

```python
def get_dict(self):
    """Get a dict representing the log. If a key appears multiple times, the first one is used."""
    result = {}
    for message in self.messages:
        ...
    # no return
```

**2. The duplicate-key warning references an undefined `key`.** It formats `key` rather than `message["key"]`, so the moment a log contains the same key twice, `get_dict()` raises:

```
NameError: name 'key' is not defined
```

**3. `dump()` opens an undefined `log_path`.** The parameter is called `output_path`, so `dump()` raises `NameError` on every call.

`ruff --select F821` flags both undefined names.

## Verification

Exercising all three paths on a small `MLPerfLog` with a deliberate duplicate key:

Before —
```
NameError: name 'key' is not defined
```

After —
```
[WARNING] There are multiple messages with key a in the log. Emprically choosing the first one.
get_dict -> {'a': 1, 'b': 3}
dump wrote 3 messages
```

So the first-one-wins behaviour the docstring promises now actually holds, the warning names the offending key, and `dump()` writes to the path it was given.

## Notes

`ruff --select F821` is clean on the file afterwards. I kept the existing wording of the warning, including the "Emprically" typo, so the diff stays limited to the defects — happy to fix the spelling too if you'd like it in the same PR.
