### PR TITLE
Fix NameError on every async query in the llama2-70b API SUT

### DIFF
--- a/language/llama2-70b/SUT_API.py
+++ b/language/llama2-70b/SUT_API.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import numpy as np
 import array


### PR DESCRIPTION
## Summary

`language/llama2-70b/SUT_API.py` calls `sys.exit()` but never imports `sys`:

```python
def async_process_query(self, input_ids_tensor, qitem_id, idx):
    ...
    lg.QuerySamplesComplete(response)
    sys.exit()          # sys is never imported in this file
```

`async_process_query` is used as a thread target:

```python
worker = threading.Thread(
    target=self.async_process_query,
    ...
)
```

so instead of the intended `SystemExit`, each worker dies with

```
NameError: name 'sys' is not defined
```

and Python's `threading.excepthook` prints a traceback for **every query**. `lg.QuerySamplesComplete(response)` has already run by then, so a run still completes and the numbers are unaffected — but the exit never happens as written and the log fills with tracebacks.

`ruff --select F821` flags it, and the file has no `import sys` anywhere (`grep -c "import sys" -> 0`).

## Fix

Add `import sys` to the import block, so the call does what it says.

## Notes

I kept this to the import rather than touching the `sys.exit()` itself: I can't tell from the code whether exiting the worker there is deliberate or a leftover, and adding the import makes the file behave as written without guessing. If it *is* a leftover, removing the line would be the better change and I'm happy to do that instead — a maintainer who knows the intent should make that call.

Heads up on overlap: #2391 also touches `SUT_API.py` (adding multinode support). I checked and it does not add `import sys`, so the two are complementary, but they will want rebasing around each other.
