### PR TITLE
Fix two NameErrors in the e2e-rag reference implementation

### DIFF
--- a/e2e-rag/evaluation.py
+++ b/e2e-rag/evaluation.py
@@ -141,8 +141,10 @@ def evaluate_retrieval_query(rag_db, query: str, expected_urls: List[str],
 
     # Step 2: Apply reranking if enabled and reranker is available
     reranking_time = 0.0
-    if not no_rerank and hasattr(
-            rag_db, '_reranker_model') and rag_db._reranker_model is not None:
+    has_reranker = (
+        getattr(rag_db, '_reranker_model', None) is not None
+    )
+    if not no_rerank and has_reranker:
         # Safety check: If no results retrieved, skip reranking
         if not results:
             if verbose:

--- a/e2e-rag/reference_SUT_datasetup.py
+++ b/e2e-rag/reference_SUT_datasetup.py
@@ -37,6 +37,9 @@ from retrieve import VectorDB
 from text_splitter import split_into_fixed_passages
 from utils import get_device_config, load_url_mapping, get_base_filename
 
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("DatasetupSUT")
+
 # Import HTML extractor
 try:
     from bs4 import BeautifulSoup
@@ -45,9 +48,6 @@ try:
 except ImportError:
     HAVE_HTML = False
     log.warning("BeautifulSoup not available - HTML processing disabled")
-
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger("DatasetupSUT")
 
 
 class DatasetupSUT:


### PR DESCRIPTION
## Summary

Two undefined names in the `e2e-rag` reference implementation, both flagged by `ruff --select F821`.

**1. `evaluation.py` — `has_reranker` is never defined.** The reranking step tests availability inline, but the verbose-output branch further down uses a name that does not exist:

```python
if not no_rerank and hasattr(
        rag_db, '_reranker_model') and rag_db._reranker_model is not None:
    ...
# ~90 lines later
if not no_rerank and has_reranker:      # NameError
```

So `retrieve_and_evaluate(..., verbose=True)` raises `NameError: name 'has_reranker' is not defined` whenever reranking actually ran. Fixed by binding the availability check once and using it in both places, which also removes the duplicated attribute chain:

```python
has_reranker = (
    getattr(rag_db, '_reranker_model', None) is not None
)
if not no_rerank and has_reranker:
```

**2. `reference_SUT_datasetup.py` — `log` is used before it exists.** The `ImportError` handler for BeautifulSoup logs a warning, but `log` is only created *after* the `try`/`except`:

```python
try:
    from bs4 import BeautifulSoup
    ...
except ImportError:
    HAVE_HTML = False
    log.warning("BeautifulSoup not available - HTML processing disabled")   # NameError

logging.basicConfig(level=logging.INFO)
log = logging.getLogger("DatasetupSUT")
```

The point of that handler is to degrade gracefully via `HAVE_HTML`, but on a machine without `bs4` the module fails to import at all with `NameError: name 'log' is not defined` — so the fallback it implements can never be reached. Fixed by moving the logger setup above the import attempt.

## Verification

`ruff --select F821 e2e-rag/` is clean afterwards, and both files parse. The second one is the more consequential of the two: it is the difference between "HTML processing disabled" and the reference SUT not importing.
