### PR TITLE
Restore IMAGE_EXTENSIONS in the text_to_image FID helper

### DIFF
--- a/text_to_image/tools/fid/fid_score.py
+++ b/text_to_image/tools/fid/fid_score.py
@@ -46,6 +46,20 @@ import os
 import sys
 from .inception import InceptionV3
 
+# Extensions accepted when a path points at a directory of images. Kept in
+# sync with the upstream pytorch-fid this module is derived from.
+IMAGE_EXTENSIONS = {
+    "bmp",
+    "jpg",
+    "jpeg",
+    "pgm",
+    "png",
+    "ppm",
+    "tif",
+    "tiff",
+    "webp",
+}
+
 
 try:
     from tqdm import tqdm


### PR DESCRIPTION
## Summary

`text_to_image/tools/fid/fid_score.py` globs an image directory using `IMAGE_EXTENSIONS`, but that name is never defined anywhere in the module:

```python
else:
    path = pathlib.Path(path)
    files = sorted(
        [file for ext in IMAGE_EXTENSIONS for file in path.glob(
            "*.{}".format(ext))]
    )
```

So `compute_statistics_of_path()` — and through it the public `calculate_fid_given_paths()` — raises `NameError: name 'IMAGE_EXTENSIONS' is not defined` for any path that is not a `.npz`. `ruff --select F821` flags it.

The constant is defined in the upstream [pytorch-fid](https://github.com/mseitzer/pytorch-fid) this file is derived from; it looks like it was dropped when the module was vendored. This adds it back with the same extension set.

## Reachability, honestly

The repo's own accuracy path is unaffected: `tools/accuracy_coco.py` passes `statistics_path`, which takes the `.npz` branch. The broken branch is reached when `calculate_fid_given_paths` is given a directory of images — the standard pytorch-fid usage and a documented shape for this public helper, but not something the benchmark's own scripts do.

So this is a latent defect rather than something breaking a submission run today. Filing it because a public function raising `NameError` on a supported input is worth having fixed, not because anything is currently failing.
